### PR TITLE
[SCRUM-16] socket 연결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@nestjs/typeorm": "^11.0.0",
         "@nestjs/websockets": "^11.1.3",
         "ioredis": "^5.6.1",
-        "n": "^10.2.0",
         "pg": "^8.16.2",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
@@ -8616,20 +8615,6 @@
       "dev": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/n": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/n/-/n-10.2.0.tgz",
-      "integrity": "sha512-zlLXwSEMQgAHmsXtcZwNuA2W5rLdAJyg51DI47ubDWE0Bss0ji9sbK3eD6vM7kKgRLTFm/i4+FvE4SXvphaSHg==",
-      "os": [
-        "!win32"
-      ],
-      "bin": {
-        "n": "bin/n"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/natural-compare": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@nestjs/typeorm": "^11.0.0",
     "@nestjs/websockets": "^11.1.3",
     "ioredis": "^5.6.1",
-    "n": "^10.2.0",
     "pg": "^8.16.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,7 +3,8 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ConfigModule } from '@nestjs/config';
-import { RedisModule } from './redis/redis.module'; // 추가된 부분
+import { RedisModule } from './redis/redis.module';
+import { CanvasModule } from './canvas/canvas.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { RedisModule } from './redis/redis.module'; // 추가된 부분
       synchronize: true,
     }),
     RedisModule,
+    CanvasModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/canvas/canvas.gateway.ts
+++ b/src/canvas/canvas.gateway.ts
@@ -1,0 +1,51 @@
+import {
+    WebSocketGateway, WebSocketServer, SubscribeMessage, MessageBody, ConnectedSocket,
+  } from '@nestjs/websockets';
+  import { Server, Socket } from 'socket.io';
+  import { CanvasService } from './canvas.service';
+  
+  @WebSocketGateway({ cors: true })
+  export class CanvasGateway {
+    @WebSocketServer()
+    server: Server;
+  
+    constructor(private readonly canvasService: CanvasService) {}
+  
+    // 클라이언트가 room 입장
+    @SubscribeMessage('join')
+    handleJoin(
+      @MessageBody() data: { canvas_id: string },
+      @ConnectedSocket() client: Socket,
+    ) {
+      client.join(data.canvas_id);
+    }
+  
+    // 채팅 이벤트
+    @SubscribeMessage('chat')
+    handleChat(
+      @MessageBody() body: { canvas_id: string; message: string },
+      @ConnectedSocket() client: Socket,
+    ) {
+      this.server.to(body.canvas_id).emit('chat', {
+        user: client.id,
+        message: body.message,
+      });
+    }
+  
+    // 픽셀 업데이트 이벤트
+    @SubscribeMessage('pixel_update')
+    async handlePixelUpdate(
+      @MessageBody() body: { canvas_id: string; x: number; y: number; color: string },
+      @ConnectedSocket() client: Socket,
+    ) {
+      // 저장 (DB/메모리 등)
+      await this.canvasService.savePixel(body.canvas_id, body.x, body.y, body.color);
+  
+      // 같은 room에 브로드캐스트
+      this.server.to(body.canvas_id).emit('pixel_update', {
+        x: body.x,
+        y: body.y,
+        color: body.color,
+      });
+    }
+  }

--- a/src/canvas/canvas.gateway.ts
+++ b/src/canvas/canvas.gateway.ts
@@ -4,48 +4,47 @@ import {
   import { Server, Socket } from 'socket.io';
   import { CanvasService } from './canvas.service';
   
-  @WebSocketGateway({ cors: true })
+  @WebSocketGateway({ 
+    cors: {
+    origin: 'http://localhost:5173',
+    credentials: true,
+    },
+  })
   export class CanvasGateway {
     @WebSocketServer()
     server: Server;
   
     constructor(private readonly canvasService: CanvasService) {}
   
-    // 클라이언트가 room 입장
-    @SubscribeMessage('join')
-    handleJoin(
-      @MessageBody() data: { canvas_id: string },
-      @ConnectedSocket() client: Socket,
-    ) {
-      client.join(data.canvas_id);
+    // 1. 클라이언트가 소켓 연결 시
+    handleConnection(client: Socket) {
+      console.log('클라이언트 연결됨:', client.id);
     }
   
-    // 채팅 이벤트
-    @SubscribeMessage('chat')
-    handleChat(
-      @MessageBody() body: { canvas_id: string; message: string },
-      @ConnectedSocket() client: Socket,
-    ) {
-      this.server.to(body.canvas_id).emit('chat', {
-        user: client.id,
-        message: body.message,
-      });
+    // 2. 클라이언트 연결 해제 시
+    handleDisconnect(client: Socket) {
+      console.log('클라이언트 연결 해제:', client.id);
     }
   
-    // 픽셀 업데이트 이벤트
-    @SubscribeMessage('pixel_update')
-    async handlePixelUpdate(
-      @MessageBody() body: { canvas_id: string; x: number; y: number; color: string },
+    // 3. 초기 캔버스 데이터 요청
+    @SubscribeMessage('get-canvas')
+    handleGetCanvas(@ConnectedSocket() client: Socket) {
+      const canvasData = this.canvasService.getAllPixels();
+      // 요청한 클라이언트에게만 전송
+      client.emit('canvas-data', canvasData);
+    }
+  
+    // 4. 픽셀 그리기 요청
+    @SubscribeMessage('draw-pixel')
+    handleDrawPixel(
+      @MessageBody() pixelData: { x: number; y: number; color: string },
       @ConnectedSocket() client: Socket,
     ) {
-      // 저장 (DB/메모리 등)
-      await this.canvasService.savePixel(body.canvas_id, body.x, body.y, body.color);
+      // 1. 유효성/동시성 검사 (선점 로직)
+      const isValid = this.canvasService.tryDrawPixel(pixelData);
+      if (!isValid) return; // 이미 선점된 픽셀이면 무시
   
-      // 같은 room에 브로드캐스트
-      this.server.to(body.canvas_id).emit('pixel_update', {
-        x: body.x,
-        y: body.y,
-        color: body.color,
-      });
+      // 2. 모든 클라이언트에게 브로드캐스트 (자기 자신 포함)
+      this.server.emit('pixel-update', pixelData);
     }
   }

--- a/src/canvas/canvas.module.ts
+++ b/src/canvas/canvas.module.ts
@@ -1,0 +1,32 @@
+import { Module } from '@nestjs/common';
+import { CanvasGateway } from './canvas.gateway';
+import { CanvasService } from './canvas.service';
+import { SubscribeMessage, ConnectedSocket, WebSocketServer } from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { MessageBody } from '@nestjs/websockets';
+
+@Module({
+  providers: [CanvasGateway, CanvasService],
+})
+export class CanvasModule {
+    @WebSocketServer()
+    server: Server;
+  @SubscribeMessage('join')
+  handleJoin(
+    @MessageBody() data: { canvas_id: string },
+    @ConnectedSocket() client: Socket,
+  ) {
+    client.join(data.canvas_id);
+  }
+
+  @SubscribeMessage('chat')
+  handleChat(
+    @MessageBody() body: { canvas_id: string; message: string },
+    @ConnectedSocket() client: Socket,
+  ) {
+    this.server.to(body.canvas_id).emit('chat', {
+      user: client.id,
+      message: body.message,
+    });
+  }
+}

--- a/src/canvas/canvas.service.ts
+++ b/src/canvas/canvas.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+
+interface PixelData {
+  x: number;
+  y: number;
+  color: string;
+}
+
+@Injectable()
+export class CanvasService {
+  // 임시: 메모리 저장 (실서비스는 DB/Redis 등 사용)
+  private pixels: Map<string, string> = new Map();
+
+  // 픽셀 선점(동시성) 로직
+  tryDrawPixel({ x, y, color }: PixelData): boolean {
+    const key = `${x},${y}`;
+    if (this.pixels.has(key)) {
+      // 이미 선점된 픽셀이면 무시
+      return false;
+    }
+    this.pixels.set(key, color);
+    return true;
+  }
+
+  // 전체 픽셀 데이터 반환
+  getAllPixels(): PixelData[] {
+    return Array.from(this.pixels.entries()).map(([key, color]) => {
+      const [x, y] = key.split(',').map(Number);
+      return { x, y, color };
+    });
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,11 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { IoAdapter } from '@nestjs/platform-socket.io';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useWebSocketAdapter(new IoAdapter(app));
 
   // Swagger 설정
   const config = new DocumentBuilder()
@@ -16,6 +18,14 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document); // /api 경로에서 Swagger UI 제공
 
-  await app.listen(process.env.PORT ?? 3000);
+  app.enableCors({
+    origin: 'http://localhost:5173',
+    credentials: true,
+  });
+   // [*] NestJS의 @WebSocketGateway()에 CORS 옵션을 이미 줬지만, NestJS는 내부적으로 Express 인스턴스를 쓰고 있기 때문에,
+   // 프론트엔드가 socket.io에 연결을 시도할 때 초기 HTTP 핸드셰이크 요청 자체가 Express에서 막히는 상황을 제거
+
+  await app.listen(process.env.PORT ?? 3000, '0.0.0.0'); 
+  //[*] 바인딩 주소 설정 안하면 도커 컨테이너 내부에서만 접근 가능
 }
 bootstrap();


### PR DESCRIPTION
클라이언트가 HTTP 핸드셰이크를 통해 WebSocket 연결을 시도하고, 서버가 이를 수락한 뒤 실제 WebSocket 세션이 열리는 흐름까지 구현했습니다.
아직 캔버스 클릭 이벤트를 통해 클라이언트에서 x, y, color 값을 전송하고, 서버에서 이를 수신하는 단계까지는 구현되지 않았습니다.

이번 PR은 백엔드 코드만 포함되어 있지만, 
로컬 환경에서 프론트엔드와 통합 테스트를 진행하기 위해서는 다음 프론트엔드 파일 일부 수정이 필요합니다:
frontend/src/components/PixelCanvas.tsx (픽셀 클릭 → 소켓 emit 연결)
frontend/package-lock.json (의존성 버전 정리)

코드 리뷰 시 잘못된 부분이나 보완이 필요한 부분이 있다면 피드백 부탁드립니다.