### PR TITLE
[SCRUM-17] canvas_id 기반 소켓 통신 및 Redis 캐싱 구조

### DIFF
--- a/src/canvas/canvas.gateway.ts
+++ b/src/canvas/canvas.gateway.ts
@@ -29,9 +29,12 @@ import {
   
     // 3. 초기 캔버스 데이터 요청
     @SubscribeMessage('get-canvas')
-    async handleGetCanvas(@ConnectedSocket() client: Socket) {
+    async handleGetCanvas(
+      @MessageBody() data: { canvas_id: string },
+      @ConnectedSocket() client: Socket
+    ) {
       try {
-        const canvasData = await this.canvasService.getAllPixels();
+        const canvasData = await this.canvasService.getAllPixels(data.canvas_id);
         // 요청한 클라이언트에게만 전송
         client.emit('canvas-data', canvasData);
       } catch (error) {

--- a/src/canvas/canvas.module.ts
+++ b/src/canvas/canvas.module.ts
@@ -4,10 +4,11 @@ import { CanvasService } from './canvas.service';
 import { DatabaseModule } from 'src/database/database.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Canvas } from './entity/canvas.entity';
+import { Pixel } from '../pixel/entity/pixel.entity';
 import { CanvasController } from './canvas.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Canvas]), DatabaseModule],
+  imports: [TypeOrmModule.forFeature([Canvas, Pixel]), DatabaseModule],
   controllers: [CanvasController],
   providers: [CanvasGateway, CanvasService],
 })

--- a/src/canvas/canvas.service.ts
+++ b/src/canvas/canvas.service.ts
@@ -3,6 +3,7 @@ import { createCanvasDto } from './dto/create_canvas_dto.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Canvas } from './entity/canvas.entity';
+import { Pixel } from '../pixel/entity/pixel.entity';
 import Redis from 'ioredis';
 import { pixelQueue } from '../queues/bullmq.queue';
 interface PixelData {
@@ -16,23 +17,119 @@ export class CanvasService {
   constructor(
     @InjectRepository(Canvas)
     private readonly canvasRepository: Repository<Canvas>,
+    @InjectRepository(Pixel)
+    private readonly pixelRepository: Repository<Pixel>,
     @Inject('REDIS_CLIENT')
     private readonly redisClient: Redis,
   ) {}
-  // 임시: 메모리 저장 (실서비스는 DB/Redis 등 사용)
-  private pixels: Map<string, string> = new Map();
 
-  // 픽셀 선점(동시성) 로직
+  // 픽셀 저장 로직 (Redis만 사용)
   async tryDrawPixel({ canvas_id, x, y, color }: PixelData & { canvas_id: string }): Promise<boolean> {
-    return true;
+    try {
+      const key = `${canvas_id}:${x}:${y}`;
+      
+      // Redis에 저장 
+      await this.redisClient.set(key, color);
+      console.log(`Redis: 픽셀 저장 성공: ${key} = ${color}`);
+      return true;
+    } catch (error) {
+      console.error('픽셀 저장 실패:', error);
+      return false;
+    }
   }
 
-  // 전체 픽셀 데이터 반환
-  getAllPixels(): PixelData[] {
-    return Array.from(this.pixels.entries()).map(([key, color]) => {
-      const [x, y] = key.split(',').map(Number);
-      return { x, y, color };
-    });
+  // 픽셀 조회 로직 (Redis 우선, 없으면 PostgreSQL)
+  async getAllPixels(canvas_id: string = 'default'): Promise<PixelData[]> {
+    try {
+      // Redis에서 먼저 조회
+      const keys = await this.redisClient.keys(`${canvas_id}:*`);
+      
+      if (keys.length > 0) {
+        const pixels: PixelData[] = [];
+        for (const key of keys) {
+          const color = await this.redisClient.get(key);
+          if (color) {
+            const [, x, y] = key.split(':');
+            pixels.push({
+              x: Number(x),
+              y: Number(y),
+              color
+            });
+          }
+        }
+        console.log(`Redis: 캔버스 ${canvas_id} 픽셀 ${pixels.length}개 조회`);
+        return pixels;
+      }
+      
+      // Redis에 없으면 PostgreSQL에서 조회
+      console.log(`Redis에 데이터 없음, PostgreSQL에서 조회: ${canvas_id}`);
+      const dbPixels = await this.pixelRepository.find({
+        where: { canvasId: Number(canvas_id) },
+        select: ['x', 'y', 'color']
+      });
+      
+      // PostgreSQL 데이터를 Redis에 캐시
+      for (const pixel of dbPixels) {
+        const key = `${canvas_id}:${pixel.x}:${pixel.y}`;
+        await this.redisClient.set(key, pixel.color);
+      }
+      
+      const pixels: PixelData[] = dbPixels.map(pixel => ({
+        x: pixel.x,
+        y: pixel.y,
+        color: pixel.color
+      }));
+      
+      console.log(`PostgreSQL: 캔버스 ${canvas_id} 픽셀 ${pixels.length}개 조회 및 Redis 캐시`);
+      return pixels;
+    } catch (error) {
+      console.error('픽셀 조회 실패:', error);
+      return [];
+    }
+  }
+
+  // 특정 픽셀 조회 (Redis만 사용)
+  async getPixel(canvas_id: string, x: number, y: number): Promise<string | null> {
+    try {
+      const key = `${canvas_id}:${x}:${y}`;
+      const color = await this.redisClient.get(key);
+      
+      if (color) {
+        console.log(`Redis: 픽셀 조회 성공: ${key} = ${color}`);
+        return color;
+      }
+      
+      console.log(`픽셀 없음: ${key}`);
+      return null;
+    } catch (error) {
+      console.error('픽셀 조회 실패:', error);
+      return null;
+    }
+  }
+
+  // 캔버스별 픽셀 개수 조회 (Redis만 사용)
+  async getPixelCount(canvas_id: string): Promise<number> {
+    try {
+      const keys = await this.redisClient.keys(`${canvas_id}:*`);
+      console.log(`Redis: 캔버스 ${canvas_id} 픽셀 ${keys.length}개`);
+      return keys.length;
+    } catch (error) {
+      console.error('픽셀 개수 조회 실패:', error);
+      return 0;
+    }
+  }
+
+  // 캔버스 초기화 (Redis만 사용)
+  async clearCanvas(canvas_id: string): Promise<void> {
+    try {
+      const keys = await this.redisClient.keys(`${canvas_id}:*`);
+      if (keys.length > 0) {
+        await this.redisClient.del(...keys);
+        console.log(`Redis: 캔버스 ${canvas_id} 픽셀 ${keys.length}개 삭제`);
+      }
+    } catch (error) {
+      console.error('캔버스 삭제 실패:', error);
+    }
   }
 
   async createCanvas(createCanvasDto: createCanvasDto): Promise<Canvas | null> {
@@ -62,6 +159,7 @@ export class CanvasService {
       return null;
     }
   }
+
   async applyDrawPixel(pixel: PixelData & { canvas_id: string }): Promise<boolean> {
     return this.tryDrawPixel(pixel);
   }


### PR DESCRIPTION
클라이언트가 get-canvas /draw-pixel 이벤트를 보냈을 때의 redis나 DB에 연결이 필요한 부분이 정상 작동 되도록 수정하였습니다,

[변경 사항]
- 클라이언트가 소켓 연결 후 join 이벤트로 canvas_id 방에 참여하도록 구현
- draw-pixel 이벤트 수신 시 해당 방에만 픽셀 변경을 브로드캐스트 (server.to(canvas_id).emit(...))
- 픽셀 상태 저장 구조를 Redis 기반으로 전환
- 저장 시: canvas_id:x:y → color 형식의 key-value 구조
- 조회 시: Redis에서 먼저 조회, 없으면 DB에서 가져온 후 Redis에 캐싱
- getAllPixels, getPixel, getPixelCount, clearCanvas 등 Redis 중심의 헬퍼 메서드 구현
- canvas 생성 시 pixelQueue에 작업 예약 (pixel-generation)
- 관련 테이블 연동을 위해 Pixel 엔티티 및 PixelRepository 추가
- CanvasGateway, CanvasService, CanvasController, CanvasModule 업데이트

**Redis와 PostgreSQL 간 동기화는 캐싱 우선 전략 기반 (쓰기: Redis, 조회: Redis → DB fallback → Redis 캐싱)**

