### PR TITLE
[SCRUM-62] /api/canvas/pixels gzip 압축 적용

### DIFF
--- a/src/queues/bullmq.worker.ts
+++ b/src/queues/bullmq.worker.ts
@@ -54,10 +54,10 @@ async function flushDirtyPixels() {
   }
 }
 
-// 10초마다 실행
+// 30초초마다 실행
 const flushInterval = setInterval(() => {
   flushDirtyPixels().catch(console.error);
-}, 10000);
+}, 30000);
 
 // 프로세스 종료 시 정리
 process.on('SIGTERM', async () => {
@@ -130,7 +130,7 @@ void (async () => {
               pixel.y = y;
               pixel.createdAt = created_at;
               pixel.updatedAt = updated_at;
-              pixel.color = 'FFFFFF';
+              pixel.color = '#FFFFFF';
               pixels.push(pixel);
             }
           }


### PR DESCRIPTION
# `/api/canvas/pixels` gzip 압축 적용

## 1. 적용 배경
- 대용량 픽셀 데이터 전송 시 네트워크 트래픽 절감 및 응답 속도 개선을 위해
- 기존에는 평문 JSON으로 전송 → **이제 gzip 압축된 JSON으로 전송**

---

## 2. 적용 범위
- **대상 API:**  
  - `GET /api/canvas/pixels`
- **비대상:**  
  - 그 외 API는 기존 평문 JSON 유지

---

## 3. 주요 변경점

- **컨트롤러(`CanvasController`)**
  - 기존: `return { ... }`로 평문 JSON 반환
  - 변경:  
    - `zlib.gzipSync`로 JSON 압축  
    - `@Res()`로 직접 응답  
    - 응답 헤더에 `Content-Encoding: gzip` 추가  
    - 예시 코드:
      ```ts
      const json = JSON.stringify(responseData);
      const gzipped = zlib.gzipSync(json);
      res.set({
        'Content-Type': 'application/json',
        'Content-Encoding': 'gzip',
      });
      res.send(gzipped);
      ```

- **Swagger 문서**
  - `@ApiResponse`의 description에  
    - “이 API는 gzip으로 압축된 JSON을 반환합니다. Content-Encoding: gzip 헤더가 포함됩니다. 아래 예시는 압축 해제 후의 JSON 구조입니다.”  
    - 압축 해제 후 예시 JSON만 표기

---

## 4. 동작 흐름

1. **클라이언트 요청**  
   - `GET /api/canvas/pixels?canvas_id=1`
2. **서버**
   - 픽셀 데이터 조회 → JSON.stringify → gzip 압축 → Buffer로 응답
   - 응답 헤더:  
     - `Content-Type: application/json`  
     - `Content-Encoding: gzip`
3. **클라이언트**
   - 브라우저/axios/fetch는 자동으로 압축 해제  
   - 평소처럼 JSON 파싱하여 사용

---

## 5. 확인 방법

- **브라우저 개발자도구 Network 탭**  
  - `Content-Encoding: gzip` 헤더 확인
- **curl로 직접 요청 후 압축 해제**
  ```bash
  curl -H "Accept: application/json" "http://localhost:3000/api/canvas/pixels?canvas_id=1" -v --output response.gz
  gzip -d response.gz
  cat response
  ```
- **Swagger 문서**  
  - description에 “gzip 압축 응답” 안내 추가됨

---

## 6. 참고/주의

- 클라이언트는 별도 처리 없이 정상 동작 (브라우저 자동 해제)
- 명세서/Swagger에 “압축 응답”임을 반드시 안내

