### PR TITLE
[SCRUM-69] group base

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,9 @@ import { UserCanvas } from './entity/UserCanvas.entity';
 import { Pixel } from './pixel/entity/pixel.entity';
 import { User } from './user/entity/user.entity';
 import { Canvas } from './canvas/entity/canvas.entity';
+import { GroupController } from './group/group.controller';
+import { GroupService } from './group/group.service';
+import { GroupModule } from './group/group.module';
 
 @Module({
   imports: [
@@ -28,7 +31,6 @@ import { Canvas } from './canvas/entity/canvas.entity';
       password: 'teamgmgdogs',
       database: 'pick_px',
       autoLoadEntities: true,
-      synchronize: true,
       entities: [User, Canvas, UserCanvas, Pixel],
     }),
     RedisModule,
@@ -36,8 +38,9 @@ import { Canvas } from './canvas/entity/canvas.entity';
     DatabaseModule,
     UserModule,
     AuthModule,
+    GroupModule,
   ],
-  controllers: [AppController, UserController],
-  providers: [AppService],
+  controllers: [AppController, UserController, GroupController],
+  providers: [AppService, GroupService],
 })
 export class AppModule {}

--- a/src/canvas/canvas.gateway.ts
+++ b/src/canvas/canvas.gateway.ts
@@ -7,6 +7,8 @@ import {
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 import { CanvasService } from './canvas.service';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 
 @WebSocketGateway({
   cors: {
@@ -29,22 +31,6 @@ export class CanvasGateway {
   handleDisconnect(client: Socket) {
     console.log('클라이언트 연결 해제:', client.id);
   }
-
-  // 초기 캔버스 데이터 요청
-  // @SubscribeMessage('get-canvas')
-  // async handleGetCanvas(
-  //   @MessageBody() data: { canvas_id: string },
-  //   @ConnectedSocket() client: Socket
-  // ) {
-  //   try {
-  //     const canvasData = await this.canvasService.getAllPixels(data.canvas_id);
-  //     // 요청한 클라이언트에게만 전송
-  //     client.emit('canvas-data', canvasData);
-  //   } catch (error) {
-  //     console.error('캔버스 데이터 조회 실패:', error);
-  //     client.emit('error', { message: '캔버스 데이터 조회 실패' });
-  //   }
-  // }
 
   // 픽셀 그리기 요청
   @SubscribeMessage('draw-pixel')
@@ -77,37 +63,5 @@ export class CanvasGateway {
     @ConnectedSocket() client: Socket
   ) {
     client.join(data.canvas_id);
-  }
-
-  @SubscribeMessage('join_chat')
-  handleJoinChat(
-    @MessageBody() data: { group_id: string; user_id: string },
-    @ConnectedSocket() client: Socket
-  ) {
-    client.join(data.group_id);
-  }
-
-  @SubscribeMessage('send_chat')
-  async handleSendChat(
-    @MessageBody() body: { group_id: string; user_id: string; message: string },
-    @ConnectedSocket() client: Socket
-  ) {
-    try {
-      // !!수정필요!! 실제로는 DB에 저장하고 messageId, user, timestamp 등 생성해야 함
-      const chatPayload = {
-        messageId: Math.floor(Math.random() * 100000), // 임시
-        user: {
-          userId: body.user_id,
-          // userName: ... // 필요시 추가
-        },
-        message: body.message,
-        timestamp: new Date().toISOString(),
-      };
-      this.server.to(body.group_id).emit('chat-message', chatPayload);
-    } catch (error) {
-      client.emit('chat-error', {
-        message: '채팅 메시지 전송 중 오류가 발생했습니다.',
-      });
-    }
   }
 }

--- a/src/canvas/canvas.module.ts
+++ b/src/canvas/canvas.module.ts
@@ -1,15 +1,19 @@
 import { Module } from '@nestjs/common';
-import { CanvasGateway } from './canvas.gateway';
-import { CanvasService } from './canvas.service';
-import { DatabaseModule } from 'src/database/database.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Canvas } from './entity/canvas.entity';
 import { Pixel } from '../pixel/entity/pixel.entity';
+import { CanvasService } from './canvas.service';
 import { CanvasController } from './canvas.controller';
+import { CanvasGateway } from './canvas.gateway';
+import { Group } from '../group/entity/group.entity'; // 추가
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Canvas, Pixel]), DatabaseModule],
+  imports: [
+    TypeOrmModule.forFeature([Canvas, Pixel, Group]), 
+    // ... 기타 모듈
+  ],
   controllers: [CanvasController],
-  providers: [CanvasGateway, CanvasService],
+  providers: [CanvasService, CanvasGateway],
+  exports: [CanvasService],
 })
 export class CanvasModule {}

--- a/src/canvas/canvas.service.ts
+++ b/src/canvas/canvas.service.ts
@@ -6,6 +6,7 @@ import { Canvas } from './entity/canvas.entity';
 import { Pixel } from '../pixel/entity/pixel.entity';
 import Redis from 'ioredis';
 import { pixelQueue } from '../queues/bullmq.queue';
+import { Group } from '../group/entity/group.entity';
 
 @Injectable()
 export class CanvasService {
@@ -14,6 +15,8 @@ export class CanvasService {
     private readonly canvasRepository: Repository<Canvas>,
     @InjectRepository(Pixel)
     private readonly pixelRepository: Repository<Pixel>,
+    @InjectRepository(Group)
+    private readonly groupRepository: Repository<Group>,
     @Inject('REDIS_CLIENT')
     private readonly redisClient: Redis
   ) {}
@@ -157,6 +160,18 @@ export class CanvasService {
         created_at: new Date(),
         updated_at: new Date(),
       });
+      //그룹 자동 생성
+      const group = this.groupRepository.create({
+        name: `canvas_${newCanvas.id}_global`,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        maxParticipants: 100,
+        currentParticipantsCount: 1,
+        canvasId: newCanvas.id,
+        madeBy: 1, // TODO: 실제 서비스에서는 로그인 유저 id로 대체
+      });
+      await this.groupRepository.save(group);
+      // =====================
       return newCanvas;
     } catch (err) {
       console.error(err);

--- a/src/canvas/entity/canvas.entity.ts
+++ b/src/canvas/entity/canvas.entity.ts
@@ -1,5 +1,6 @@
 import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
 import { UserCanvas } from '../../entity/UserCanvas.entity';
+import { Group } from '../../group/entity/group.entity';
 @Entity('canvases')
 export class Canvas {
   @PrimaryGeneratedColumn()
@@ -28,4 +29,7 @@ export class Canvas {
 
   @OneToMany(() => UserCanvas, (uc) => uc.canvas)
   canvasUseres: UserCanvas[];
+
+  @OneToMany(() => Group, (group) => group.canvas)
+  groups: Group[];
 }

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -4,6 +4,8 @@ import { Canvas } from './canvas/entity/canvas.entity';
 import { Pixel } from './pixel/entity/pixel.entity';
 import { UserCanvas } from './entity/UserCanvas.entity';
 import { User } from './user/entity/user.entity';
+import { Group } from './group/entity/group.entity';
+import { Chat } from './group/entity/chat.entity';
 export const AppDataSource = new DataSource({
   type: 'postgres',
   host: 'postgres',
@@ -11,6 +13,7 @@ export const AppDataSource = new DataSource({
   username: 'pixel_user',
   password: 'teamgmgdogs', // 환경 변수로 대체해도 좋음
   database: 'pick_px',
-  entities: [Canvas, Pixel, UserCanvas, User],
+  entities: [Canvas, Pixel, UserCanvas, User, Group, Chat],
   synchronize: false,
 });
+

--- a/src/group/dto/chat-message.dto.ts
+++ b/src/group/dto/chat-message.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ChatMessageDto {
+  @ApiProperty()
+  id: number;
+  @ApiProperty()
+  user: { id: number; user_name: string };
+  @ApiProperty()
+  message: string;
+  @ApiProperty()
+  created_at: Date;
+} 

--- a/src/group/entity/chat.entity.ts
+++ b/src/group/entity/chat.entity.ts
@@ -1,0 +1,32 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { Group } from './group.entity';
+import { User } from '../../user/entity/user.entity';
+
+@Entity('chats')
+export class Chat {
+  @PrimaryGeneratedColumn({ type: 'bigint' })
+  id: number;
+
+  @Column({ name: 'group_id', type: 'bigint' })
+  groupId: number;
+
+  @Column({ name: 'user_id', type: 'bigint' })
+  userId: number;
+
+  @Column({ type: 'varchar', length: 50 })
+  message: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+
+  @ManyToOne(() => Group, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'group_id' })
+  group: Group;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+} 

--- a/src/group/entity/group.entity.ts
+++ b/src/group/entity/group.entity.ts
@@ -1,0 +1,39 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, OneToMany, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { Canvas } from '../../canvas/entity/canvas.entity';
+import { User } from '../../user/entity/user.entity';
+
+@Entity('groups')
+export class Group {
+  @PrimaryGeneratedColumn({ type: 'bigint' })
+  id: number;
+
+  @Column({ type: 'varchar', length: 50, unique: true })
+  name: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+
+  @Column({ name: 'max_participants', type: 'int' })
+  maxParticipants: number;
+
+  @Column({ name: 'current_participants_count', type: 'int', default: 1 })
+  currentParticipantsCount: number;
+
+  @Column({ name: 'canvas_id', type: 'bigint' })
+  canvasId: number;
+
+  @Column({ name: 'made_by', type: 'bigint' })
+  madeBy: number;
+
+  @ManyToOne(() => Canvas, (canvas) => canvas.groups, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'canvas_id' })
+  canvas: Canvas;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'made_by' })
+  madeByUser: User;
+
+} 

--- a/src/group/group.controller.spec.ts
+++ b/src/group/group.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GroupController } from './group.controller';
+
+describe('GroupController', () => {
+  let controller: GroupController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [GroupController],
+    }).compile();
+
+    controller = module.get<GroupController>(GroupController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/group/group.controller.ts
+++ b/src/group/group.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, Param, NotFoundException, Query } from '@nestjs/common';
+import { GroupService } from './group.service';
+import { ChatMessageDto } from './dto/chat-message.dto';
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+
+@ApiTags('Group')
+@Controller('group')
+export class GroupController {
+  constructor(private readonly groupService: GroupService) {}
+
+  @Get('by-canvas')
+  @ApiOkResponse({  schema: { example: { group_id: 1 } } })
+  async getGroupIdByCanvas(@Query('canvasId') id: string,) {
+    const groupId = await this.groupService.getGroupIdByCanvasId(Number(id));
+    if (!groupId) throw new NotFoundException('Group not found for this canvas');
+    return { group_id: groupId };
+  }
+
+  @Get(':groupId/chats')
+  @ApiOkResponse({ type: [ChatMessageDto] })
+  async getRecentChats(@Param('groupId') groupId: string): Promise<ChatMessageDto[]> {
+    const chats = await this.groupService.getRecentChatsByGroupId(Number(groupId));
+    return chats.map(chat => ({
+      id: chat.id,
+      user: {
+        id: chat.user.id,
+        user_name: chat.user.userName,
+      },
+      message: chat.message,
+      created_at: chat.createdAt,
+    }));
+  }
+}

--- a/src/group/group.gateway.ts
+++ b/src/group/group.gateway.ts
@@ -1,0 +1,76 @@
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  SubscribeMessage,
+  MessageBody,
+  ConnectedSocket,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Chat } from './entity/chat.entity';
+import { User } from '../user/entity/user.entity';
+import { ChatMessageDto } from './dto/chat-message.dto';
+
+@WebSocketGateway({
+  cors: {
+    origin: ['http://localhost:5173', 'https://ws.pick-px.com'],
+    credentials: true,
+  },
+})
+export class GroupGateway {
+  @WebSocketServer()
+  server: Server;
+
+  constructor(
+    @InjectRepository(Chat)
+    private readonly chatRepository: Repository<Chat>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  @SubscribeMessage('join_chat')
+  handleJoinChat(
+    @MessageBody() data: { group_id: string; user_id: string },
+    @ConnectedSocket() client: Socket
+  ) {
+    client.join(data.group_id);
+  }
+
+  @SubscribeMessage('send_chat')
+  async handleSendChat(
+    @MessageBody() body: { group_id: string; user_id: string; message: string },
+    @ConnectedSocket() client: Socket
+  ) {
+    try {
+      // DB에 저장
+      const chat = this.chatRepository.create({
+        groupId: Number(body.group_id),
+        userId: Number(body.user_id),
+        message: body.message,
+      });
+      const savedChat = await this.chatRepository.save(chat);
+      // 유저 정보 조회
+      const user = await this.userRepository.findOne({ where: { id: Number(body.user_id) } });
+      if (!user) {
+        client.emit('chat-error', { message: '유저 정보를 찾을 수 없습니다.' });
+        return;
+      }
+      // 브로드캐스트
+      const chatPayload: ChatMessageDto = {
+        id: savedChat.id,
+        user: {
+          id: user.id,
+          user_name: user.userName,
+        },
+        message: savedChat.message,
+        created_at: savedChat.createdAt,
+      };
+      this.server.to(body.group_id).emit('chat-message', chatPayload);
+    } catch (error) {
+      client.emit('chat-error', {
+        message: '채팅 메시지 전송 중 오류가 발생했습니다.',
+      });
+    }
+  }
+} 

--- a/src/group/group.module.ts
+++ b/src/group/group.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Group } from './entity/group.entity';
+import { Chat } from './entity/chat.entity';
+import { User } from '../user/entity/user.entity';
+import { GroupService } from './group.service';
+import { GroupController } from './group.controller';
+import { GroupGateway } from './group.gateway';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Group, Chat, User]),
+  ],
+  providers: [GroupService, GroupGateway],
+  controllers: [GroupController],
+  exports: [GroupService, TypeOrmModule],
+})
+export class GroupModule {}

--- a/src/group/group.service.spec.ts
+++ b/src/group/group.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GroupService } from './group.service';
+
+describe('GroupService', () => {
+  let service: GroupService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [GroupService],
+    }).compile();
+
+    service = module.get<GroupService>(GroupService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/group/group.service.ts
+++ b/src/group/group.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Group } from './entity/group.entity';
+import { Chat } from './entity/chat.entity';
+
+@Injectable()
+export class GroupService {
+  constructor(
+    @InjectRepository(Group)
+    private readonly groupRepository: Repository<Group>,
+  ) {}
+
+  async getGroupIdByCanvasId(canvasId: number): Promise<number | null> {
+    const group = await this.groupRepository.findOne({ where: { canvasId } });
+    return group ? group.id : null;
+  }
+
+  async getRecentChatsByGroupId(groupId: number): Promise<Chat[]> {
+    return this.groupRepository.manager.find(Chat, {
+      where: { groupId },
+      order: { createdAt: 'DESC' },
+      take: 50,
+      relations: ['user'],
+    });
+  }
+}

--- a/src/user/entity/user.entity.ts
+++ b/src/user/entity/user.entity.ts
@@ -1,7 +1,7 @@
 import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
 import { UserCanvas } from '../../entity/UserCanvas.entity';
 
-@Entity('Users')
+@Entity('users')
 export class User {
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -60,6 +60,8 @@ export class UserService {
     const payload = this.generateParam(code, site);
     const url = this.generateUrl(site);
     let response: { data: CommonTokenResponse };
+    console.log('payload', payload);
+    console.log('url', url);
     try {
       response = await firstValueFrom(
         this.httpService.post(url, payload.toString(), {
@@ -68,8 +70,10 @@ export class UserService {
           },
         })
       );
+      console.log('response', response);
     } catch (err) {
-      console.error(err);
+      console.log("에러발생");
+      //console.error(err);
       throw new Error('토큰 요청 중 오류 발생');
     }
 
@@ -90,6 +94,7 @@ export class UserService {
         'EX',
         SEVEN_DAYS_IN_SECONDS
       );
+      console.log('result', result);
       return result;
     } else if (site === 'kakao') {
       const data = response.data as KakaoTokenResponse;


### PR DESCRIPTION
## 1. 전체 구조 및 흐름

- **캔버스 생성 시**
    
    → 해당 캔버스에 대한 전체 채팅 그룹(그룹 채팅방)이 자동으로 생성됨
    
- **로그인한 사용자가 채팅을 열면**
    
    → 자동으로 현재 캔버스의 전체 채팅방(그룹)에 연결됨
    
- **채팅 메시지**
    
    → DB에 저장되고, 실시간 소켓으로 같은 그룹에 브로드캐스트됨
    

---

## 2. 폴더/파일 구조

```
backend/src/
  canvas/
    canvas.gateway.ts      # 픽셀 관련 소켓만 담당
    canvas.service.ts      # 캔버스 생성/픽셀 처리/그룹 자동 생성
    entity/
      canvas.entity.ts
  group/
    group.gateway.ts       # 채팅(그룹) 관련 소켓 담당
    group.controller.ts    # 그룹/채팅 REST API
    group.service.ts       # 그룹/채팅 DB 로직
    dto/
      chat-message.dto.ts  # 채팅 메시지/리스트 응답 DTO
    entity/
      group.entity.ts
      chat.entity.ts

```

---

## 3. REST API 명세

### 1) 캔버스별 그룹 ID 조회

- **GET /group/by-canvas/:canvasId**
- **응답**
    
    ```json
    { "group_id": 1 }
    
    ```
    

### 2) 그룹별 최근 50개 채팅 조회

- **GET /group/:groupId/chats**
- **응답**
    
    ```json
    [
      {
        "id": 123,
        "user": { "id": 1, "user_name": "홍길동" },
        "message": "안녕하세요",
        "created_at": "2024-06-01T12:34:56.000Z"
      }
    ]
    
    ```
    

---

## 4. 소켓 명세

### 1) 채팅방 입장

- **이벤트명:** `join_chat`
- [**](http://localhost/)전송 데이터**
    
    ```json
    { "group_id": "1", "user_id": "1" }
    
    ```
    

### 2) 채팅 전송

- **이벤트명:** `send_chat`
- **전송 데이터**
    
    ```json
    { "group_id": "1", "user_id": "1", "message": "안녕하세요" }
    
    ```
    
- **수신 이벤트:** `chat-message`
- **수신 데이터**
    
    ```json
    {
      "id": 123,
      "user": { "id": 1, "user_name": "홍길동" },
      "message": "안녕하세요",
      "created_at": "2024-06-01T12:34:56.000Z"
    }
    
    ```
    

---

## 5. DTO 구조 (공통)

### ChatMessageDto

```tsx
export class ChatMessageDto {
  id: number;
  user: { id: number; user_name: string };
  message: string;
  created_at: Date;
}

```

---

## 6. Swagger 연동 및 API 테스트

- 서버 실행 후[**http://localhost/](http://localhost/):포트/api-docs**
에 접속하면 모든 REST API 명세와 테스트가 가능

---

## 7. 개발/확장 참고

- 캔버스별 전체 채팅방은 자동 생성/매핑됨
- 그룹/채팅 관련 소켓 로직은 group 폴더에서만 관리
- REST/소켓 응답 구조는 DTO로 통일
- 추후 그룹 채팅(비공개/소규모 등) 확장도 용이

---

## 8. 프론트엔드 연동 흐름

1. 캔버스 진입 → `/group/by-canvas`로 group_id 조회
2. 소켓 연결 후 `join_chat` 이벤트로 group_id, user_id 전송
3. 채팅 전송 시 `send_chat` 이벤트 사용
4. 채팅 내역은 REST로 50개까지 불러올 수 있음