### PR TITLE
[SCRUM-99] WebSocket 인증 구조 리팩토링

### DIFF
--- a/sql/schema.sql/schema.sql
+++ b/sql/schema.sql/schema.sql
@@ -82,7 +82,7 @@ create table if not exists groups
     made_by bigint not null,
     is_default boolean not null default false,
     primary key (id),
-    unique (name),
+    unique (canvas_id, name),
     constraint fk_canvas
         foreign key (canvas_id) references canvases(id)
             on delete cascade,

--- a/src/app.gateway.ts
+++ b/src/app.gateway.ts
@@ -5,10 +5,11 @@ import {
   WebSocketServer,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
+import { JwtService } from '@nestjs/jwt';
 
 @WebSocketGateway({
   cors: {
-    origin: ['http://localhost:5173', 'https://ws.pick-px.com'],
+    origin: ['http://localhost:5173', 'https://ws.pick-px.com', 'https://pick-px.com'],
     credentials: true,
   },
 })
@@ -16,7 +17,36 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer()
   server: Server;
 
-  handleConnection(client: any, ...args: any[]) {}
+  constructor(private readonly jwtService: JwtService) {}
 
-  handleDisconnect(client: any) {}
+  handleConnection(client: Socket) {
+    console.log('[DEBUG] handleConnection 결과:', client);
+    const user = this.getUserFromSocket(client);
+    console.log('[DEBUG] getUserFromSocket 결과:', user);
+    if (user) {
+      (client as any).user = user;
+      console.log(`[AppGateway] 클라이언트 연결(로그인):`, user);
+      console.log('소켓 연결 시 유저 정보:', (client as any).user);
+    } else {
+      console.log(`[AppGateway] 클라이언트 연결(비로그인):`, client.id);
+      // 연결은 유지, context에 user 저장 안함
+    }
+  }
+
+  handleDisconnect(client: Socket) {
+    console.log(`[AppGateway] 유저 연결 해제:`, client.id);
+  }
+
+  // JWT 토큰에서 유저 정보 추출
+  getUserFromSocket(client: Socket): any {
+    try {
+      const token = client.handshake.auth?.token || client.handshake.headers?.authorization?.split(' ')[1];
+      if (!token) return null;
+      const payload = this.jwtService.verify(token) as any;
+      return payload?.sub || payload || null;
+    } catch (err) {
+      console.error('[소켓 토큰 verify 실패]', err);
+      return null;
+    }
+  }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import { GroupModule } from './group/group.module';
 import { Group } from './group/entity/group.entity';
 import { GroupUser } from './entity/GroupUser.entity';
 import { HttpModule } from '@nestjs/axios';
+import { AppGateway } from './app.gateway';
 
 @Module({
   imports: [
@@ -45,6 +46,6 @@ import { HttpModule } from '@nestjs/axios';
     HttpModule,
   ],
   controllers: [AppController, UserController, GroupController],
-  providers: [AppService, GroupService],
+  providers: [AppService, GroupService, AppGateway],
 })
 export class AppModule {}

--- a/src/group/group.gateway.ts
+++ b/src/group/group.gateway.ts
@@ -1,24 +1,17 @@
-import {
-  WebSocketGateway,
-  WebSocketServer,
-  SubscribeMessage,
-  MessageBody,
-  ConnectedSocket,
-} from '@nestjs/websockets';
+import { WebSocketGateway, WebSocketServer, SubscribeMessage, MessageBody, ConnectedSocket } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Chat } from './entity/chat.entity';
 import { User } from '../user/entity/user.entity';
 import { ChatMessageDto } from './dto/chat-message.dto';
-import { JwtService } from '@nestjs/jwt';
 import Redis from 'ioredis';
 import { GroupUser } from '../entity/GroupUser.entity';
 import { Group } from './entity/group.entity';
 
 @WebSocketGateway({
   cors: {
-    origin: ['http://localhost:5173', 'https://ws.pick-px.com'],
+    origin: ['http://localhost:5173', 'https://ws.pick-px.com', 'https://pick-px.com'],
     credentials: true,
   },
 })
@@ -37,22 +30,23 @@ export class GroupGateway {
     private readonly groupUserRepository: Repository<GroupUser>,
     @InjectRepository(Group)
     private readonly groupRepository: Repository<Group>,
-    private readonly jwtService: JwtService
   ) {
     this.redisClient = new Redis(process.env.REDIS_URL || 'redis://redis:6379');
   }
 
-  // JWT 토큰에서 userId 추출
-  private getUserIdFromSocket(client: Socket): number | null {
-    try {
-      const token = client.handshake.auth?.token || client.handshake.headers?.authorization?.split(' ')[1];
-      if (!token) return null;
-      const payload = this.jwtService.decode(token) as any;
-      // JWT payload 구조: { sub: { userId: "123", nickName: "사용자명" } }
-      return Number(payload?.sub?.userId || payload?.userId || payload?.id);
-    } catch {
-      return null;
-    }
+  // 헬퍼: 인증 유저 ID 추출
+  private getUserIdFromClient(client: Socket): number | null {
+    const user = (client as any).user;
+    if (!user || (!user.userId && !user.id)) return null;
+    return Number(user.userId || user.id);
+  }
+
+  // 헬퍼: 그룹 멤버십 체크
+  private async checkGroupMembership(userId: number, groupId: number): Promise<GroupUser | null> {
+    return await this.groupUserRepository.findOne({
+      where: { user: { id: userId }, group: { id: groupId } },
+      relations: ['user', 'group'],
+    });
   }
 
   // 클라이언트가 특정 그룹 채팅방에 입장할 때 호출
@@ -61,16 +55,13 @@ export class GroupGateway {
     @MessageBody() data: { group_id: string },
     @ConnectedSocket() client: Socket
   ) {
-    const userIdFromToken = this.getUserIdFromSocket(client);
-    if (!userIdFromToken) {
-      client.emit('chat-error', { message: '인증 정보가 올바르지 않습니다.' });
+    const userId = this.getUserIdFromClient(client);
+    if (!userId) {
+      client.emit('auth-error', { message: '인증 정보가 올바르지 않습니다.' });
       return;
     }
     // 그룹 참여 여부 확인
-    const isMember = await this.groupUserRepository.findOne({
-      where: { user: { id: userIdFromToken }, group: { id: Number(data.group_id) } },
-      relations: ['user', 'group'],
-    });
+    const isMember = await this.checkGroupMembership(userId, Number(data.group_id));
     if (!isMember) {
       client.emit('chat-error', { message: '이 채팅방에 참여할 권한이 없습니다.' });
       return;
@@ -91,7 +82,6 @@ export class GroupGateway {
     @MessageBody() data: { group_id: string },
     @ConnectedSocket() client: Socket
   ) {
-    // group_id 룸에서 leave
     client.leave(data.group_id);
   }
 
@@ -102,16 +92,13 @@ export class GroupGateway {
     @ConnectedSocket() client: Socket
   ) {
     try {
-      const userIdFromToken = this.getUserIdFromSocket(client);
-      if (!userIdFromToken) {
-        client.emit('chat-error', { message: '인증 정보가 올바르지 않습니다.' });
+      const userId = this.getUserIdFromClient(client);
+      if (!userId) {
+        client.emit('auth-error', { message: '인증 정보가 올바르지 않습니다.' });
         return;
       }
       // 그룹 참여 여부 확인
-      const isMember = await this.groupUserRepository.findOne({
-        where: { user: { id: userIdFromToken }, group: { id: Number(body.group_id) } },
-        relations: ['user', 'group'],
-      });
+      const isMember = await this.checkGroupMembership(userId, Number(body.group_id));
       if (!isMember) {
         client.emit('chat-error', { message: '이 채팅방에 참여할 권한이 없습니다.' });
         return;
@@ -121,7 +108,7 @@ export class GroupGateway {
       const chatPayload = {
         // Redis에 저장되는 채팅 메시지의 id는 Date.now()로 임시로 부여됨, flush 시 DB에 저장할 때는 실제 DB의 auto-increment id가 부여됨
         id: Date.now(),
-        user: { id: userIdFromToken, user_name: isMember.user.userName },
+        user: { id: userId, user_name: isMember.user.userName },
         message: body.message,
         created_at: now.toISOString(),
       };


### PR DESCRIPTION
### 1. **공통 인증 처리 구조 도입**
- **AppGateway**: 전역 소켓 연결 관리 및 JWT 인증 처리
- **CanvasGateway, GroupGateway**: 이벤트 핸들러만 담당, 인증 로직 제거

### 2. **파일별 변경 내용**

**`backend/src/app.module.ts`**
```typescript
// AppGateway를 providers에 추가
providers: [AppService, GroupService, AppGateway],
```

**`backend/src/app.gateway.ts`**
- 전역 소켓 연결/해제 관리
- JWT 토큰 파싱 및 `client.user` 설정
- 모든 Gateway에서 공통으로 사용할 인증 정보 제공

**`backend/src/canvas/canvas.gateway.ts`**
- JwtService 주입 제거
- handleConnection, getUserFromSocket 메서드 제거
- AppGateway에서 설정한 `client.user`만 활용

**`backend/src/group/group.gateway.ts`**
- JwtService 주입 제거  
- handleConnection, getUserFromSocket 메서드 제거
- AppGateway에서 설정한 `client.user`만 활용

### 해결된 문제

1. **소켓 연결 문제 해결**: 클라이언트 연결 시도 시 서버가 응답하지 않던 문제
2. **인증 중복 제거**: 각 Gateway에서 개별적으로 JWT 파싱하던 중복 로직 제거
3. **코드 구조 개선**: 공통 인증 로직을 AppGateway로 중앙화

###  동작 방식

1. **소켓 연결 시**: AppGateway의 handleConnection에서 JWT 토큰 파싱
2. **인증 정보 저장**: `client.user`에 유저 정보 저장
3. **이벤트 처리**: CanvasGateway, GroupGateway에서 `client.user` 활용
