### PR TITLE
[SCRUM-116]  UserCanvas 레포 추가, 엔티티 및 스키마 시드 정리

### DIFF
--- a/sql/schema.sql/schema.sql
+++ b/sql/schema.sql/schema.sql
@@ -117,7 +117,6 @@ create table if not exists chats
     user_id bigint not null,
     message varchar(50) not null,
     created_at timestamp not null,
-    updated_at timestamp not null,
     primary key(id),
     constraint fk_groups
         foreign key (group_id) references groups(id) on delete cascade,
@@ -128,7 +127,7 @@ create table if not exists chats
 alter table chats
     owner to pixel_user;
 
--- 관리자 계정 seed (id=1, email=pickpx0617@gmail.com, user_name=gmg team)
-INSERT INTO users (id, email, password, created_at, updated_at, user_name)
-VALUES (1, 'pickpx0617@gmail.com', NULL, '2025-06-17 00:00:00.000000', '2025-06-17 00:00:00.000000', 'gmg team')
-ON CONFLICT (id) DO NOTHING;
+-- 관리자 계정 seed (email=pickpx0617@gmail.com, user_name=gmg team)
+INSERT INTO users (email, password, created_at, updated_at, user_name)
+VALUES ('pickpx0617@gmail.com', NULL, '2025-06-17 00:00:00.000000', '2025-06-17 00:00:00.000000', 'gmg team')
+ON CONFLICT (email) DO NOTHING;

--- a/src/canvas/canvas.module.ts
+++ b/src/canvas/canvas.module.ts
@@ -6,12 +6,13 @@ import { CanvasService } from './canvas.service';
 import { CanvasController } from './canvas.controller';
 import { CanvasGateway } from './canvas.gateway';
 import { Group } from '../group/entity/group.entity'; // 추가
+import { UserCanvas } from '../entity/UserCanvas.entity';
 import { JwtModule } from '@nestjs/jwt';
 import { AuthModule } from '../auth/auth.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Canvas, Pixel, Group]), 
+    TypeOrmModule.forFeature([Canvas, Pixel, Group, UserCanvas]), 
     JwtModule.register({}),
     AuthModule,
     // ... 기타 모듈

--- a/src/entity/UserCanvas.entity.ts
+++ b/src/entity/UserCanvas.entity.ts
@@ -21,6 +21,9 @@ export class UserCanvas {
   @JoinColumn({ name: 'canvas_id' })
   canvas: Canvas;
 
+  @Column({ name: 'count', type: 'integer', default: 0 })
+  count: number;
+
   @Column({ name: 'joined_at', type: 'timestamp' })
   joinedAt: Date;
 }

--- a/src/group/entity/chat.entity.ts
+++ b/src/group/entity/chat.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, CreateDateColumn } from 'typeorm';
 import { Group } from './group.entity';
 import { User } from '../../user/entity/user.entity';
 
@@ -18,9 +18,6 @@ export class Chat {
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
-
-  @UpdateDateColumn({ name: 'updated_at' })
-  updatedAt: Date;
 
   @ManyToOne(() => Group, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'group_id' })

--- a/src/group/group.controller.ts
+++ b/src/group/group.controller.ts
@@ -107,7 +107,6 @@ export class GroupController {
           HttpStatus.BAD_REQUEST
         );
       }
-      console.log(req.user);
       const user_id = req.user?._id;
       if (!user_id) {
         throw new HttpException(
@@ -122,7 +121,7 @@ export class GroupController {
           HttpStatus.UNAUTHORIZED
         );
       }
-      console.log(user);
+      console.log('user', user_id, 'open chat in canvas', canvasId);
       // 해당 캔버스에서 유저가 참여중인 그룹 리스트만 조회
       const groups = await this.groupService.findUserGroupsByCanvasId(
         user.id,

--- a/src/group/group.service.ts
+++ b/src/group/group.service.ts
@@ -48,7 +48,6 @@ export class GroupService {
         userId: chat.user.id,
         message: chat.message,
         createdAt: new Date(chat.created_at),
-        updatedAt: new Date(chat.created_at),
         user: {
           id: chat.user.id,
           userName: chat.user.user_name


### PR DESCRIPTION

## 주요 변경사항

### 1. 채팅 엔티티 정리
- `chat.entity.ts`에서 `updatedAt` 컬럼 제거
- `schema.sql`에서 `chats` 테이블의 `updated_at` 컬럼 제거
- 채팅 메시지 불변성 보장

### 2. 동시성 제어 추가(머지한 내용)
- `canvas.service.ts`에 Redis 분산락 구현
- 동시 픽셀 그리기 시 데이터 일관성 보장

### 3. 사용자 참여 카운팅 기능
- `UserCanvas` Repository 추가
- 픽셀 그리기 시 자동으로 사용자 카운트 증가

### 4. 모듈 의존성 업데이트
- `canvas.module.ts`에 `UserCanvas` 엔티티 추가

### 5. 스키마 시드 데이터 수정
- `schema.sql`에서 관리자 계정 시드의 `id` 지정 제거
- `ON CONFLICT (id)` → `ON CONFLICT (email)`로 변경

## 기술적 개선
- Redis NX 락으로 동시성 제어
- Lua 스크립트로 안전한 락 해제
- 채팅 메시지 불변성 확보
- 시드 데이터 충돌 처리 개선