### PR TITLE
[SCRUM-134] 채팅 레디스 복제/중복 저장 버그 수정 및 그룹별 캐싱 구조 개선

### DIFF
--- a/src/group/group.gateway.ts
+++ b/src/group/group.gateway.ts
@@ -125,7 +125,7 @@ export class GroupGateway {
         created_at: now.toISOString(),
       };
       // Redis에 저장 (12시간 TTL)
-      const chatKey = `chat:${body.group_id}`;
+      const chatKey = `chat:${Number(body.group_id)}`;
       await this.redis.lpush(chatKey, JSON.stringify(chatPayload));
       
       // 채팅 리스트 크기 제한 (최대 50개)


### PR DESCRIPTION
## 요약  
- 채팅 메시지가 레디스에 중복(복제) 저장되는 현상을 해결  
- 그룹별로 채팅 캐시가 분리되어 저장/조회/동기화되도록 구조 개선  
- flush 후 레디스-DB 동기화 및 key 관리 일관성 강화

---

## 상세 설명

- **문제 원인**  
  - 채팅 flush 후에도 레디스에 임시 id/실제 id가 혼용되어 남아 중복 저장
  - group_id가 key에 제대로 반영되지 않아, 여러 그룹의 채팅이 한 리스트에 섞여 저장됨
  - 레디스에 50개 미만일 때 DB에서 추가로 가져와 합치는 로직으로 인해 중복 반환

- **해결 방법**  
  - 채팅 저장/조회/동기화 시 key를 항상 `chat:{groupId}`로 생성(타입 일관성 보장)
  - flush 후에는 해당 groupId의 DB 기준 최신 50개만 레디스에 덮어써 임시 id 제거
  - 채팅 조회는 오직 레디스 데이터만 반환하도록 수정

---

## 주요 변경점

1. **레디스 채팅 key를 그룹별(`chat:{groupId}`)로 분리**
   - 기존에는 group_id가 올바르게 key에 반영되지 않아, 여러 그룹의 채팅이 한 리스트에 섞여 저장되는 문제가 있었음
   - 모든 채팅 저장/조회/동기화 로직에서 groupId를 number로 변환하여 key에 반영

2. **flush 후 레디스 동기화 로직 개선**
   - 채팅이 DB에 저장된 후, 해당 groupId의 최신 50개 채팅만 DB에서 읽어와 레디스에 덮어씀
   - 임시 id로 저장된 채팅이 남아 중복되는 현상 제거

3. **채팅 조회 시 오직 레디스 데이터만 반환**
   - 레디스에 50개 미만일 때도 DB에서 추가로 가져와 합치지 않음
   - 중복 반환 문제 완전 해결

4. **코드 일관성 및 타입 안정성 강화**
   - group_id, chat_id 등 key 생성 시 항상 number로 변환
   - flush, 동기화, 조회 등 모든 경로에서 일관된 key 사용
