### PR TITLE
[SCRUM-145] chat redis fallback

### DIFF
--- a/src/canvas/canvas.gateway.ts
+++ b/src/canvas/canvas.gateway.ts
@@ -83,11 +83,13 @@ export class CanvasGateway {
         })
       );
 
-      // canvas_id 방에만 브로드캐스트
-      this.server.to(pixel.canvas_id).emit('pixel_update', {
-        x: pixel.x,
-        y: pixel.y,
-        color: pixel.color,
+      // 비동기 브로드캐스트 (응답 속도 향상)
+      setImmediate(() => {
+        this.server.to(`canvas_${pixel.canvas_id}`).emit('pixel_update', {
+          x: pixel.x,
+          y: pixel.y,
+          color: pixel.color,
+        });
       });
 
       console.log(
@@ -104,7 +106,7 @@ export class CanvasGateway {
     @MessageBody() data: { canvas_id: string },
     @ConnectedSocket() client: Socket
   ) {
-    await client.join(data.canvas_id);
+    await client.join(`canvas_${data.canvas_id}`);
     // 쿨다운 정보 자동 푸시
     const userId = this.getUserIdFromClient(client);
     if (userId && data.canvas_id) {
@@ -161,7 +163,7 @@ export class CanvasGateway {
 
       // 비동기 브로드캐스트 (응답 속도 향상)
       setImmediate(() => {
-        this.server.to(pixel.canvas_id).emit('pixel_update', {
+        this.server.to(`canvas_${pixel.canvas_id}`).emit('pixel_update', {
           x: pixel.x,
           y: pixel.y,
           color: pixel.color,

--- a/src/group/group.gateway.ts
+++ b/src/group/group.gateway.ts
@@ -72,18 +72,26 @@ export class GroupGateway {
       });
       return;
     }
-    // 기존 group_id 룸에서 leave (canvas_id 룸은 유지)
+    
+    // 이미 해당 그룹 룸에 있으면 아무것도 하지 않음
+    if (client.rooms.has(`group_${data.group_id}`)) {
+      console.log(`[GroupGateway] 이미 그룹 ${data.group_id}에 참여 중`);
+      return;
+    }
+    
+    // 기존 그룹 룸에서만 leave (캔버스 룸은 유지)
     const currentRooms = Array.from(client.rooms);
     for (const room of currentRooms) {
+      // 그룹 룸만 체크 (group_ 접두사가 있는 룸이 그룹 룸, canvas_ 룸은 유지)
       if (
         room !== client.id &&
-        room !== data.group_id &&
-        !room.startsWith('canvas_')
+        room !== `group_${data.group_id}` &&
+        room.startsWith('group_')
       ) {
         client.leave(room);
       }
     }
-    client.join(data.group_id);
+    client.join(`group_${data.group_id}`);
   }
 
   // 채팅방에서 나갈 때 호출
@@ -92,7 +100,7 @@ export class GroupGateway {
     @MessageBody() data: { group_id: string },
     @ConnectedSocket() client: Socket
   ) {
-    client.leave(data.group_id);
+    client.leave(`group_${data.group_id}`);
   }
 
   // 클라이언트가 채팅 메시지를 전송할 때 호출, Redis에 저장 및 브로드캐스트
@@ -140,8 +148,10 @@ export class GroupGateway {
         chatData: chatPayload
       }));
       
-      // 브로드캐스트
-      this.server.to(body.group_id).emit('chat_message', chatPayload);
+      // 비동기 브로드캐스트 (응답 속도 향상)
+      setImmediate(() => {
+        this.server.to(`group_${body.group_id}`).emit('chat_message', chatPayload);
+      });
     } catch (error) {
       client.emit('chat_error', {
         message: '채팅 메시지 전송 중 오류가 발생했습니다.',

--- a/src/group/group.service.ts
+++ b/src/group/group.service.ts
@@ -35,27 +35,73 @@ export class GroupService {
     groupId: number,
     take: number
   ): Promise<Chat[]> {
-    // Redis에서 최근 메시지만 조회 (최대 50개로 제한)
+    // Redis에서 최근 메시지 조회 (최대 50개로 제한)
     const redisChats = await this.redis.lrange(`chat:${Number(groupId)}`, 0, Math.min(take, 50) - 1);
     
-    // Redis에 있는 메시지들 파싱
-    const redisMessages = redisChats
-      .map(chatStr => JSON.parse(chatStr))
-      .filter(chat => chat.id && chat.user && chat.message) // 유효한 메시지만
-      .map(chat => ({
-        id: Number(chat.id),
-        groupId,
-        userId: chat.user.id,
-        message: chat.message,
-        createdAt: new Date(chat.created_at),
-        user: {
-          id: chat.user.id,
-          userName: chat.user.user_name
-        }
-      })) as Chat[];
+    // Redis에 데이터가 있으면 파싱해서 반환
+    if (redisChats.length > 0) {
+      const redisMessages = redisChats
+        .map(chatStr => JSON.parse(chatStr))
+        .filter(chat => chat.id && chat.user && chat.message) // 유효한 메시지만
+        .map(chat => ({
+          id: Number(chat.id),
+          groupId,
+          userId: chat.user.id,
+          message: chat.message,
+          createdAt: new Date(chat.created_at),
+          user: {
+            id: chat.user.id,
+            userName: chat.user.user_name
+          }
+        })) as Chat[];
+      
+      return redisMessages.slice(0, take);
+    }
     
-    // Redis에 있는 메시지만 반환
-    return redisMessages.slice(0, take);
+    // Redis에 데이터가 없으면 DB에서 가져와서 Redis에 캐싱
+    console.log(`[캐시 미스] 그룹 ${groupId}의 채팅을 DB에서 가져와서 Redis에 캐싱`);
+    
+    try {
+      const chatRepo = this.dataSource.getRepository(Chat);
+      const dbChats = await chatRepo.find({
+        where: { groupId },
+        order: { createdAt: 'DESC' },
+        take: 50, // 최대 50개만 가져오기
+        relations: ['user'],
+      });
+      
+      if (dbChats.length === 0) {
+        return []; // DB에도 데이터가 없으면 빈 배열 반환
+      }
+      
+      // Redis에 저장할 포맷으로 변환
+      const chatPayloads = dbChats.map((chat) => ({
+        id: chat.id,
+        user: { id: chat.user.id, user_name: chat.user.userName },
+        message: chat.message,
+        created_at: chat.createdAt.toISOString(),
+      }));
+      
+      // Redis에 캐싱 (기존 데이터 삭제 후)
+      const chatKey = `chat:${Number(groupId)}`;
+      await this.redis.del(chatKey);
+      if (chatPayloads.length > 0) {
+        await this.redis.lpush(chatKey, ...chatPayloads.map((p) => JSON.stringify(p)));
+        await this.redis.ltrim(chatKey, 0, 49); // 최대 50개만 유지
+        await this.redis.expire(chatKey, 12 * 60 * 60); // 12시간 TTL
+      }
+      
+      console.log(`[캐시 복구] 그룹 ${groupId}의 채팅 ${dbChats.length}개를 Redis에 캐싱 완료`);
+      
+      // 요청된 개수만큼 반환 (최신순으로 정렬)
+      return dbChats
+        .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()) // 오래된 순으로 정렬
+        .slice(0, take);
+        
+    } catch (error) {
+      console.error(`[캐시 복구 실패] 그룹 ${groupId}의 DB 조회 중 에러:`, error);
+      return []; // 에러 발생 시 빈 배열 반환
+    }
   }
 
   async createGroup(

--- a/src/queues/bullmq.worker.ts
+++ b/src/queues/bullmq.worker.ts
@@ -182,6 +182,12 @@ async function flushChatBatch(isForceFlush: boolean = false) {
       `[Worker] 채팅 ${flushType} 완료: 개수=${chatBatchQueue.length}`
     );
 
+    // flush 후 각 그룹별로 Redis 동기화
+    const groupIds = [...new Set(chatBatchQueue.map(({ groupId }) => groupId))];
+    for (const groupId of groupIds) {
+      await syncRedisChatAfterFlush(groupId);
+    }
+
     chatBatchQueue.length = 0; // 배열 비우기
   } catch (error) {
     console.error(`[Worker] 채팅 배치 flush 에러:`, error);


### PR DESCRIPTION
## 문제 상황
1. **Redis TTL 만료 시 데이터 손실**: 12시간 TTL 만료로 채팅 내역 사라짐
2. **임시 ID 문제**: Redis에 임시 ID로 저장된 채팅이 DB 저장 후에도 임시 ID 유지
3. **룸 충돌 문제**: 캔버스 ID와 그룹 ID가 같을 때 룸 충돌 발생
4. **비효율적인 룸 관리**: 그룹 채팅 이동 시 불필요한 룸 변경

## 해결

```
[레디스에 데이터가 있는 경우]
채팅 메시지 → Redis 임시 저장 → 배치 flush → DB 저장 → Redis 동기화 → 실제 DB ID로 업데이트

[레디스에 데이터가 없는 경우 : TTL 만료]
채팅 내역 요청 → Redis 조회 → 캐시 미스 → DB 조회 → Redis 재캐싱 → 실제 DB ID로 반환
```

### 1. **Redis TTL 복구 로직 추가**
- `getRecentChatsByGroupId`에 캐시 미스 처리 로직 구현
- Redis에 데이터 없을 때 DB에서 복구하여 Redis에 재캐싱
- 에러 처리 및 로깅 추가

### 2. **채팅 배치 flush 후 Redis 동기화**
- `flushChatBatch`에서 DB 저장 후 각 그룹별 Redis 동기화
- 임시 ID를 실제 DB ID로 업데이트
- 그룹별 개별 처리로 중복 동기화 방지

### 3. **소켓 룸 이름 구분화**
- 캔버스 룸: `canvas_` + `canvas_id`
- 그룹 룸: `group_` + `group_id`
- 룸 충돌 완전 방지

### 4. **브로드캐스트 성능 최적화**
- `setImmediate()`를 사용한 비동기 브로드캐스트
- 응답 속도 향상 및 동시성 개선

### 5. **룸 관리 효율성 개선**
- 중복 참여 방지 로직 추가
- 불필요한 룸 변경 최소화

## 변경 사항

### `backend/src/group/group.service.ts`
- Redis 캐시 미스 시 DB fallback 로직 구현
- 자동 캐시 복구 및 재저장 기능 추가
- 캐시 미스/복구 과정 로깅 추가

### `backend/src/queues/bullmq.worker.ts`
- `flushChatBatch`에서 DB 저장 후 Redis 동기화 로직 추가
- `syncRedisChatAfterFlush` 함수 활용하여 실제 DB ID로 업데이트

### `backend/src/group/group.gateway.ts`
- 룸 이름에 `group_` 접두사 추가
- 중복 참여 방지 로직 추가
- 비동기 브로드캐스트 구현

### `backend/src/canvas/canvas.gateway.ts`
- 룸 이름에 `canvas_` 접두사 추가
- 비동기 브로드캐스트 구현
