### PR TITLE
SCRUM-149 :  캔버스 시작시간 추가 및 그룹 방장 정보 전달 기능 구현

### DIFF
--- a/sql/schema/schema.sql
+++ b/sql/schema/schema.sql
@@ -23,10 +23,10 @@ create table if not exists canvases
     title      varchar(50) not null,
     type       varchar(50)        not null,
     created_at timestamp   not null,
+    started_at timestamp   not null default now(),
     ended_at   timestamp   not null,
     size_x     integer     not null,
     size_y     integer     not null,
-    is_active boolean default false not null,
     primary key (id)
 );
 

--- a/src/canvas/dto/create_canvas_dto.dto.ts
+++ b/src/canvas/dto/create_canvas_dto.dto.ts
@@ -37,8 +37,16 @@ export class createCanvasDto {
 
   @ApiProperty({
     example: '2024-01-01T00:00:00.000Z',
-    description:
-      '캔버스 종료일입니다. Date 값으로 받습니다. 상시 캔버스인 경우 그냥 null로 보내도 됩니다.',
+    description: '캔버스 시작일 (ISO8601 형식)',
+  })
+  @IsNotEmpty()
+  @IsDate()
+  startedAt: Date;
+
+  @ApiProperty({
+    example: '2024-12-31T23:59:59.000Z',
+    description: '캔버스 종료일 (ISO8601 형식, 상시 캔버스는 null 가능)',
+    required: false,
   })
   @IsDate()
   endedAt: Date;

--- a/src/canvas/entity/canvas.entity.ts
+++ b/src/canvas/entity/canvas.entity.ts
@@ -18,6 +18,9 @@ export class Canvas {
   @Column({ type: 'timestamp', name: 'created_at' })
   createdAt: Date;
 
+  @Column({ type: 'timestamp', name: 'started_at', nullable: true, default: () => 'CURRENT_TIMESTAMP' })
+  startedAt: Date;
+
   @Column({ type: 'timestamp', name: 'ended_at', nullable: true })
   endedAt: Date;
 
@@ -26,9 +29,6 @@ export class Canvas {
 
   @Column({ name: 'size_y' })
   sizeY: number;
-
-  @Column({ type: 'boolean', name: 'is_active' })
-  is_active: boolean;
 
   @OneToMany(() => UserCanvas, (uc) => uc.canvas)
   canvasUseres: UserCanvas[];

--- a/src/group/dto/chat-init-response.dto.ts
+++ b/src/group/dto/chat-init-response.dto.ts
@@ -12,6 +12,12 @@ export class GroupInfoDto {
     description: '그룹 제목',
   })
   group_title: string;
+
+  @ApiProperty({
+    example: '123',
+    description: '그룹 방장(생성자) ID',
+  })
+  made_by: string;
 }
 
 export class ChatMessageResponseDto {

--- a/src/group/group.controller.ts
+++ b/src/group/group.controller.ts
@@ -161,6 +161,7 @@ export class GroupController {
           groups: groups.map((g) => ({
             group_id: String(g.id),
             group_title: g.name,
+            made_by: String(g.madeBy),
           })),
           messages: messages.map((m) => ({
             messageId: m.id,
@@ -273,9 +274,21 @@ export class GroupController {
       groupIdNum,
       limitNum
     );
+    const groupInfo = await this.groupService.findGroupById(groupIdNum);
+    if (!groupInfo) {
+      throw new HttpException(
+        { success: false, error: 'Group not found' },
+        HttpStatus.NOT_FOUND
+      );
+    }
     return {
       success: true,
       data: {
+        group: {
+          group_id: String(groupInfo.id),
+          group_title: groupInfo.name,
+          made_by: String(groupInfo.madeBy),
+        },
         messages: messages.map((m) => ({
           messageId: m.id,
           user: { userId: String(m.user.id), name: m.user.userName },

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -221,6 +221,8 @@ export class UserService {
         canvasId: uc.canvas.id,
         title: uc.canvas.title,
         created_at: uc.canvas.createdAt,
+        started_at: uc.canvas.startedAt,
+        ended_at: uc.canvas.endedAt,
         size_x: uc.canvas.sizeX,
         size_y: uc.canvas.sizeY,
       }));


### PR DESCRIPTION
## **핵심 변경사항 요약**

### **1. 시간 기반 활성 상태 판단**
-  이전: `is_active` 컬럼 기반
-  현재: `started_at`, `ended_at` 시간 기반

### **2. 캔버스 리스트 동작 변경**
-  이전: 시작된 캔버스만 표시
-  현재: 종료되지 않은 모든 캔버스 표시 (시작 전 포함)

### **3. 정보 완전성**
-  모든 캔버스 관련 API에서 `started_at` 정보 포함
-  모든 채팅 관련 API에서 `made_by` 정보 포함

### **4. 사용자 경험**
-  즉시 차단: 색칠 시도 전 페이지 접근 시점에 차단
-  명확한 에러 메시지: 시작/종료 시간 정보 포함

---

### **1. DB 스키마 수정**
-  **`canvases` 테이블**: `started_at` 컬럼 추가, `is_active` 컬럼 제거
-  **마이그레이션 스크립트**: 삭제됨 (더 이상 존재하지 않음)

### **2. 엔티티 수정**
-  **`Canvas` 엔티티**: `startedAt` 필드 추가, `is_active` 필드 제거
-  **`nullable: false`**: DB 스키마와 일치하도록 수정

### **3. 캔버스 생성 로직**
-  **`createCanvasDto`**: `startedAt` 필드 추가 (Swagger 포함)
-  **`createCanvas`**: 클라이언트에서 받은 `startedAt` 값 사용

### **4. 캔버스 리스트 조회 로직 변경**
```sql
-- 이전 (활성만)
WHERE started_at <= NOW() AND (ended_at IS NULL OR ended_at > NOW())

-- 현재 (종료되지 않은 모든 캔버스)
WHERE (ended_at IS NULL OR ended_at > NOW())
```

### **5. API 응답 수정**

#### **캔버스 조회 API** (`/api/canvas`)
```json
{
  "success": true,
  "data": {
    "id": "1",
    "title": "이벤트 캔버스",
    "type": "event",
    "createdAt": "2024-07-10T12:00:00Z",
    "startedAt": "2024-07-15T00:00:00Z",  // ← 추가됨
    "endedAt": "2024-08-01T00:00:00Z",
    "sizeX": 1000,
    "sizeY": 1000
  }
}
```

#### **캔버스 리스트 API** (`/api/canvas/list`)
```json
{
  "canvases": [
    {
      "canvasId": 1,
      "title": "My First Canvas",
      "type": "public",
      "created_at": "2025-01-15T09:30:00Z",
      "started_at": "2025-07-10T12:00:00Z",  // ← 추가됨
      "ended_at": null,
      "size_x": 100,
      "size_y": 100
    }
  ]
}
```

#### **픽셀 데이터 API** (`/api/canvas/pixels`)
```json
{
  "success": true,
  "data": {
    "canvas_id": "1",
    "title": "이벤트 캔버스",
    "type": "event",
    "startedAt": "2024-07-15T00:00:00Z",  // ← 추가됨
    "endedAt": "2024-08-01T00:00:00Z",
    "pixels": [...],
    "compression": "gzip",
    "totalPixels": 5000,
    "canvasSize": {
      "width": 1000,
      "height": 1000
    }
  }
}
```

#### **사용자 정보 API** (`/api/user/info`)
```json
{
  "email": "user@example.com",
  "nickName": "사용자",
  "canvases": [
    {
      "canvasId": 1,
      "title": "캔버스 제목",
      "created_at": "2025-07-10T12:00:00Z",
      "started_at": "2025-07-15T00:00:00Z",  // ← 추가됨
      "ended_at": "2025-08-01T00:00:00Z",    // ← 추가됨
      "size_x": 1000,
      "size_y": 1000
    }
  ]
}
```

### **6. 채팅 관련 수정**

#### **채팅 초기화 API** (`/api/group/init/chat`)
```json
{
  "success": true,
  "data": {
    "defaultGroupId": "1",
    "groups": [
      {
        "group_id": "1",
        "group_title": "전체",
        "made_by": "123"  // ← 추가됨
      }
    ],
    "messages": [...]
  }
}
```

#### **채팅 기록 API** (`/api/group/chat`)
```json
{
  "success": true,
  "data": {
    "group": {
      "group_id": "1",
      "group_title": "전체",
      "made_by": "123"  // ← 추가됨
    },
    "messages": [...]
  }
}
```

### **7. DTO 수정**
-  **`GroupInfoDto`**: `made_by` 필드 추가
-  **`createCanvasDto`**: `startedAt` 필드 추가 (Swagger 포함)

### **8. 활성 상태 차단 로직**
-  **페이지 접근 시점 차단**: `/api/canvas/pixels`, `/api/canvas`에서 비활성 캔버스 접근 시 403 에러
-  **성능 최적화**: 픽셀 그리기에서 불필요한 활성 상태 체크 제거

### **9. 에러 처리**
```json
// 시작 전 캔버스
{
  "success": false,
  "message": "캔버스가 아직 시작되지 않았습니다.",
  "startedAt": "2024-07-15T00:00:00.000Z"
}

// 종료된 캔버스
{
  "success": false,
  "message": "캔버스가 이미 종료되었습니다.",
  "endedAt": "2024-08-01T00:00:00.000Z"
}
```
