### PR TITLE
[SCRUM-171] 멀티서버 Redis 연결 안정성 개선

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,9 +1,16 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Res } from '@nestjs/common';
 import { AppService } from './app.service';
+import { Response } from 'express';
+import { Inject } from '@nestjs/common';
+import Redis from 'ioredis';
 
 @Controller()
 export class AppController {
-  constructor(private readonly appService: AppService) {}
+  constructor(
+    private readonly appService: AppService,
+    @Inject('REDIS_CLIENT')
+    private readonly redis: Redis
+  ) {}
 
   @Get()
   getHello(): string {
@@ -11,11 +18,43 @@ export class AppController {
   }
 
   @Get('health')
-  getHealth(): object {
-    return {
-      status: 'ok',
-      timestamp: new Date().toISOString(),
-      service: 'nestjs-app',
-    };
+  async getHealth(@Res() res: Response) {
+    try {
+      // Redis 연결 상태 확인
+      const redisStatus = this.redis.status;
+      const redisPing = await this.redis.ping();
+      
+      const healthStatus = {
+        status: 'healthy',
+        timestamp: new Date().toISOString(),
+        services: {
+          redis: {
+            status: redisStatus,
+            ping: redisPing === 'PONG' ? 'ok' : 'failed'
+          }
+        },
+        server: {
+          uptime: process.uptime(),
+          memory: process.memoryUsage(),
+          pid: process.pid
+        }
+      };
+
+      if (redisStatus === 'ready' && redisPing === 'PONG') {
+        res.status(200).json(healthStatus);
+      } else {
+        res.status(503).json({
+          ...healthStatus,
+          status: 'unhealthy',
+          error: 'Redis connection issue'
+        });
+      }
+    } catch (error) {
+      res.status(503).json({
+        status: 'unhealthy',
+        timestamp: new Date().toISOString(),
+        error: error.message
+      });
+    }
   }
 }

--- a/src/app.gateway.ts
+++ b/src/app.gateway.ts
@@ -36,28 +36,57 @@ export class AppGateway implements OnGatewayConnection, OnGatewayDisconnect, OnG
   ) {}
 
   afterInit(server: Server) {
-    // Redis Adapter 설정
+    console.log('[AppGateway] afterInit 메서드 호출됨');
+    
+    // Redis Adapter 설정 (멀티서버 환경 최적화)
     const pubClient = this.redis;
     const subClient = this.redis.duplicate();
     
-    server.adapter(createAdapter(pubClient, subClient));
-    console.log('[AppGateway] Redis Adapter 설정 완료');
-
-    // 서버 시작 시 이전 소켓 ID들 정리
-    this.cleanupOldSockets();
-
-    // 모든 이벤트에 대한 디버그 리스너 추가
-    server.on('connection', (socket) => {
-      console.log(`[AppGateway] 클라이언트 연결됨: ${socket.id}`);
-      
-      // 모든 이벤트 로깅
-      socket.onAny((eventName, ...args) => {
-        console.log(`[AppGateway] 이벤트 수신 [${eventName}] from ${socket.id}:`, args);
+    console.log('[AppGateway] Redis 상태 확인 중...', pubClient.status);
+    console.log('[AppGateway] Redis 객체 타입:', typeof pubClient);
+    console.log('[AppGateway] Redis 연결 상태:', pubClient.status);
+    
+    // Redis Adapter 설정 전 연결 상태 확인
+    if (pubClient.status === 'ready') {
+      console.log('[AppGateway] Redis 연결 준비됨, Adapter 설정 시작');
+      this.setupRedisAdapter(server, pubClient, subClient);
+    } else {
+      console.log('[AppGateway] Redis 연결 대기 중... 현재 상태:', pubClient.status);
+      pubClient.on('ready', () => {
+        console.log('[AppGateway] Redis 연결 준비됨, Adapter 설정 시작');
+        this.setupRedisAdapter(server, pubClient, subClient);
       });
-    });
+      
+      // 연결 실패 시 대비
+      pubClient.on('error', (error) => {
+        console.error('[AppGateway] Redis 연결 에러:', error);
+      });
+    }
+  }
 
-    // 주기적 접속자 수 업데이트 시작
-    this.startPeriodicUserCountBroadcast();
+  private setupRedisAdapter(server: Server, pubClient: Redis, subClient: Redis) {
+    try {
+      server.adapter(createAdapter(pubClient, subClient));
+      console.log('[AppGateway] Redis Adapter 설정 완료');
+      
+      // 서버 시작 시 이전 소켓 ID들 정리
+      this.cleanupOldSockets();
+
+      // 모든 이벤트에 대한 디버그 리스너 추가
+      server.on('connection', (socket) => {
+        console.log(`[AppGateway] 클라이언트 연결됨: ${socket.id}`);
+        
+        // 모든 이벤트 로깅
+        socket.onAny((eventName, ...args) => {
+          console.log(`[AppGateway] 이벤트 수신 [${eventName}] from ${socket.id}:`, args);
+        });
+      });
+
+      // 주기적 접속자 수 업데이트 시작
+      this.startPeriodicUserCountBroadcast();
+    } catch (error) {
+      console.error('[AppGateway] Redis Adapter 설정 실패:', error);
+    }
   }
 
   // 서버 시작 시 이전 소켓 ID들 정리

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -80,6 +80,18 @@ import { AwsModule } from './aws/aws.module';
     AwsModule,
   ],
   controllers: [AppController],
-  providers: [AppService, AppGateway],
+  providers: [
+    AppService, 
+    // Gateway 초기화 순서 보장
+    {
+      provide: 'GATEWAY_INITIALIZATION',
+      useFactory: async (appGateway: AppGateway) => {
+        console.log('[AppModule] Gateway 초기화 순서 보장');
+        return appGateway;
+      },
+      inject: [AppGateway],
+    },
+    AppGateway,
+  ],
 })
 export class AppModule {}

--- a/src/group/group.gateway.ts
+++ b/src/group/group.gateway.ts
@@ -48,10 +48,42 @@ export class GroupGateway implements OnGatewayInit {
   ) {}
 
   afterInit(server: Server) {
-    // Redis Adapter 설정
+    console.log('[GroupGateway] afterInit 메서드 호출됨');
+    
+    // AppGateway, canvasGateway 초기화 완료 대기
+    setTimeout(() => {
+      this.initializeRedisAdapter(server);
+    }, 2000); // 2초 대기
+  }
+
+  private initializeRedisAdapter(server: Server) {
+    // Redis Adapter 설정 (멀티서버 환경 최적화)
     const pubClient = this.redis;
     const subClient = this.redis.duplicate();
     
+    console.log('[GroupGateway] Redis 상태 확인 중...', pubClient.status);
+    console.log('[GroupGateway] Redis 객체 타입:', typeof pubClient);
+    console.log('[GroupGateway] Redis 연결 상태:', pubClient.status);
+    
+    // Redis Adapter 설정 전 연결 상태 확인
+    if (pubClient.status === 'ready') {
+      console.log('[GroupGateway] Redis 연결 준비됨, Adapter 설정 시작');
+      this.setupRedisAdapter(server, pubClient, subClient);
+    } else {
+      console.log('[GroupGateway] Redis 연결 대기 중... 현재 상태:', pubClient.status);
+      pubClient.on('ready', () => {
+        console.log('[GroupGateway] Redis 연결 준비됨, Adapter 설정 시작');
+        this.setupRedisAdapter(server, pubClient, subClient);
+      });
+      
+      // 연결 실패 시 대비
+      pubClient.on('error', (error) => {
+        console.error('[GroupGateway] Redis 연결 에러:', error);
+      });
+    }
+  }
+
+  private setupRedisAdapter(server: Server, pubClient: Redis, subClient: Redis) {
     server.adapter(createAdapter(pubClient, subClient));
     console.log('[GroupGateway] Redis Adapter 설정 완료');
   }

--- a/src/redis/redis.module.ts
+++ b/src/redis/redis.module.ts
@@ -28,7 +28,7 @@ useFactory: (configService: ConfigService) => {
       },
 */
 
-// === Redis 클라이언트 팩토리 함수 (통합 버전) ===
+// === Redis 클라이언트 팩토리 함수 (멀티서버 환경 최적화) ===
 const createRedisClient = (configService: ConfigService): Redis => {
   const redisUrl = configService.get<string>('REDIS_URL');
   const host = configService.get<string>('REDIS_HOST') || 'redis';
@@ -52,9 +52,12 @@ const createRedisClient = (configService: ConfigService): Redis => {
         console.log(`[Redis] 재연결 시도 ${times}회, ${delay}ms 후 재시도`);
         return delay;
       },
-      lazyConnect: true,
-      connectTimeout: 10000,
-      commandTimeout: 5000,
+      lazyConnect: false, // 즉시 연결 시도
+      connectTimeout: 15000,
+      commandTimeout: 10000,
+      keepAlive: 30000,
+      family: 4, // IPv4 강제 사용
+      enableReadyCheck: true,
     });
   } else {
     // 로컬 개발: 기존 설정 사용
@@ -64,7 +67,12 @@ const createRedisClient = (configService: ConfigService): Redis => {
       port,
       password: password || undefined,
       db,
-      lazyConnect: true,
+      lazyConnect: false, // 즉시 연결 시도
+      connectTimeout: 10000,
+      commandTimeout: 5000,
+      keepAlive: 30000,
+      family: 4,
+      enableReadyCheck: true,
     });
   }
 
@@ -73,12 +81,24 @@ const createRedisClient = (configService: ConfigService): Redis => {
     console.log(`[Redis] 연결 성공: ${host}:${port}`);
   });
 
+  redis.on('ready', () => {
+    console.log(`[Redis] 준비 완료: ${host}:${port} (상태: ${redis.status})`);
+  });
+
   redis.on('error', (error) => {
     console.error(`[Redis] 연결 에러:`, error);
   });
 
   redis.on('close', () => {
     console.log(`[Redis] 연결 종료`);
+  });
+
+  redis.on('reconnecting', (delay) => {
+    console.log(`[Redis] 재연결 시도 중... ${delay}ms 후`);
+  });
+
+  redis.on('end', () => {
+    console.log(`[Redis] 연결 종료됨`);
   });
 
   return redis;


### PR DESCRIPTION
## 변경사항

### Redis 연결 설정 개선
- `lazyConnect: false`로 즉시 연결 시도
- 연결/명령 타임아웃 시간 증가 (10s → 15s, 5s → 10s)
- `keepAlive` 및 `enableReadyCheck` 설정 추가
- IPv4 강제 사용으로 호환성 향상

### Gateway 초기화 순서 보장
- AppGateway → CanvasGateway → GroupGateway 순서로 초기화
- Redis Adapter 중복 설정 방지
- Gateway 간 의존성 해결

## 개선 효과
- 멀티서버 환경에서 Redis 연결 안정성 향상
- Gateway 초기화 충돌 방지
- 로그 가독성 개선

## 테스트 방법
1. 로컬 환경에서 서버 재시작
2. Redis Adapter 설정 완료 로그 확인
3. 멀티서버 배포 후 소켓 연결 테스트