### PR TITLE
[SCRUM-176] 참여 캔버스별 try_count, own_count 응답 및 명세 개선

### DIFF
--- a/src/user/dto/user_info_dto.dto.ts
+++ b/src/user/dto/user_info_dto.dto.ts
@@ -1,32 +1,71 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 class userCanvasInfo {
-  @ApiProperty()
+  @ApiProperty({ example: 1 })
   canvasId: number;
 
-  @ApiProperty()
+  @ApiProperty({ example: 'My First Canvas' })
   title: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: '2025-01-15T09:30:00Z' })
   created_at: Date;
 
-  @ApiProperty()
+  @ApiProperty({ example: '2025-07-15T00:00:00Z' })
+  started_at: Date;
+
+  @ApiProperty({ example: '2025-08-01T00:00:00Z' })
+  ended_at: Date;
+
+  @ApiProperty({ example: 100 })
   size_x: number;
-  @ApiProperty()
+
+  @ApiProperty({ example: 100 })
   size_y: number;
+
+  @ApiProperty({ example: 15 })
+  try_count: number;
+
+  @ApiProperty({ nullable: true, example: 7, description: '캔버스 종료 전에는 null, 종료 후에는 본인이 소유한 픽셀 수' })
+  own_count: number | null;
 }
 
 class UserInfoResponseDto {
-  @ApiProperty()
+  @ApiProperty({ example: 'user@example.com' })
   email: string;
 
-  @ApiProperty()
+  @ApiProperty({ example: '2025-01-01T00:00:00Z' })
   createdAt: Date;
 
-  @ApiProperty()
+  @ApiProperty({ example: 'nickname123' })
   nickName: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    type: [userCanvasInfo],
+    example: [
+      {
+        canvasId: 1,
+        title: 'My First Canvas',
+        created_at: '2025-01-15T09:30:00Z',
+        started_at: '2025-07-15T00:00:00Z',
+        ended_at: '2025-08-01T00:00:00Z',
+        size_x: 100,
+        size_y: 100,
+        try_count: 15,
+        own_count: 7
+      },
+      {
+        canvasId: 2,
+        title: 'Project Artwork',
+        created_at: '2025-02-20T14:00:00Z',
+        started_at: '2025-07-15T00:00:00Z',
+        ended_at: '2025-08-01T00:00:00Z',
+        size_x: 200,
+        size_y: 150,
+        try_count: 3,
+        own_count: null
+      }
+    ]
+  })
   canvases: userCanvasInfo[];
 }
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -225,6 +225,11 @@ export class UserService {
         ended_at: uc.canvas.endedAt,
         size_x: uc.canvas.sizeX,
         size_y: uc.canvas.sizeY,
+        try_count: uc.tryCount,
+        own_count:
+          uc.canvas.endedAt && uc.canvas.type !== 'public'
+            ? uc.ownCount
+            : null,
       }));
       return {
         email: user.email,


### PR DESCRIPTION
1. **user/info API 응답에 참여한 각 캔버스별로 아래 필드 추가**
   - **try_count, own_count는 user_canvas 테이블의 값을 그대로 사용**
   - `try_count`: 유저가 해당 캔버스에서 픽셀을 찍은(시도한) 총 횟수 (항상 반환)
   - `own_count`:  
     - 캔버스가 종료된 경우(단, public 제외): 유저가 소유한 픽셀 수  
     - 캔버스가 종료되지 않았거나 public인 경우: null 반환

2. **Swagger/DTO 명세 개선**
   - 각 필드에 example, 설명, null 가능성 등 명확히 표기
   - 실제 응답 예시(example) 추가

---

### 프론트엔드 참고사항

- own_count가 null이면 “집계 중” 또는 “집계 불가(public)”로 표시하면 됨
- try_count는 항상 값이 내려감