### PR TITLE
[SCRUM-205]  Gallery API Presigned URL 적용

### DIFF
--- a/src/canvas/canvas.module.ts
+++ b/src/canvas/canvas.module.ts
@@ -22,6 +22,7 @@ import { PublicCanvasStrategy } from './strategy/publicCanvasStrategy.strategy';
 import { GameCalculationCanvasStrategy } from './strategy/gameCalculationCanvasStrategy.strategy';
 import { EventCommonCanvasStrategy } from './strategy/eventCommonCanvasStrategy.strategy';
 import { EventColorLimitCanvasStrategy } from './strategy/eventColorLimitCanvasStrategy.strategy';
+import { AwsModule } from '../aws/aws.module';
 
 @Module({
   imports: [
@@ -40,6 +41,7 @@ import { EventColorLimitCanvasStrategy } from './strategy/eventColorLimitCanvasS
     GroupModule,
     PixelModule,
     forwardRef(() => GameModule), // GameModule 추가
+    AwsModule, // AwsModule 추가
   ],
   controllers: [CanvasController, GalleryController],
   providers: [


### PR DESCRIPTION
### 주요 변경사항

1. **갤러리 API에서 S3 presigned URL 반환**
    - 기존에는 DB에 저장된 S3 key(이미지 경로)를 그대로 반환했으나,
    이제는 presigned URL(일시적 접근 가능한 URL)로 변환하여 반환합니다.
    - presigned URL은 만료 시간이 있으며, API 호출 시마다 동적으로 생성됩니다.
2. **CanvasHistoryService 개선**
    - `AwsService`를 DI로 주입받아 presigned URL을 생성하도록 변경
    - `getGalleryData()`에서 각 row의 S3 key(`image_url`)를 presigned URL로 변환
    - presigned URL 생성 및 실패 시 로그 추가
3. **SQL 쿼리 컬럼명 수정**
    - 기존: `c.url as image_url` (컬럼 없음 → 500 에러)
    - 변경: `ch.image_url as image_url` (canvas_history 테이블의 컬럼 사용)
4. **모듈 의존성 추가**
    - `CanvasModule`에 `AwsModule` import 추가

---

### AWS S3 Presigned URL이란?

- S3에 저장된 객체(이미지 등)는 기본적으로 비공개로 두는 것이 보안상 안전
- presigned URL은 S3 객체에 대해 **일시적으로 접근 권한이 부여된 URL**
- 서버에서 AWS SDK를 통해 presigned URL을 생성하여,
클라이언트가 해당 URL로 일정 시간 동안만 이미지를 직접 다운로드/조회할 수 있게 함
- 이 방식은 S3 버킷을 public으로 열지 않고도 안전하게 파일을 제공함

---

### 적용 예시

- 클라이언트가 `/api/gallery` 호출 →
서버가 presigned URL을 포함한 갤러리 데이터를 반환 →
클라이언트는 해당 URL로 이미지를 안전하게 조회

