### PR TITLE
[SCRUM-208]  Gallery bugfix - DB저장::UTC, 프론트로 반환:KST

### DIFF
--- a/src/canvas/canvas-history.service.ts
+++ b/src/canvas/canvas-history.service.ts
@@ -137,8 +137,8 @@ export class CanvasHistoryService {
       LEFT JOIN users top_try_user ON ch.top_try_user_id = top_try_user.id
       LEFT JOIN users top_own_user ON ch.top_own_user_id = top_own_user.id
       WHERE c.ended_at IS NOT NULL 
-        AND c.ended_at <= NOW()
-        AND c.type IN ('event', 'game')
+        AND c.ended_at <= (NOW() AT TIME ZONE 'Asia/Seoul')
+        AND c.type IN ('event_common', 'event_colorlimit', 'game_calculation')
       ORDER BY c.ended_at DESC
     `;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { IoAdapter } from '@nestjs/platform-socket.io';
 import { Express } from 'express';
 import * as dotenv from 'dotenv';
-import './worker/start.worker';
+import './worker/alarm.worker';
 import { ValidationPipe } from '@nestjs/common';
 const cookieParser = require('cookie-parser');
 


### PR DESCRIPTION
- DB 및 백엔드 비교/저장은 UTC 기준으로 통일
- 프론트로 반환 시 KST로 변환하여 전달 (또는 프론트에서 KST 변환)
- 시간대 이슈로 인한 갤러리 노출 버그 수정