### PR TITLE
[Deploy] ingress pod 개수 증가 세팅 및 환경변수 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,6 +133,11 @@ jobs:
             --from-literal=google-client-id="${{ secrets.GOOGLE_CLIENT_ID }}" \
             --from-literal=google-client-secret="${{ secrets.GOOGLE_CLIENT_SECRET }}" \
             --from-literal=google-redirect-uri="${{ secrets.GOOGLE_REDIRECT_URI }}" \
+            --from-literal=aws-access-key-id="${{ secrets.AWS_ACCESS_KEY_ID }}" \
+            --from-literal=aws-secret-access-key="${{ secrets.AWS_SECRET_ACCESS_KEY }}" \
+            --from-literal=aws-region="${{ secrets.AWS_REGION }}" \
+            --from-literal=aws-s3-bucket="${{ secrets.AWS_S3_BUCKET }}" \
+
             --namespace=$NAMESPACE \
             --dry-run=client -o yaml | kubectl apply -f -
 

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: nestjs-app
     component: api
 spec:
-  replicas: 3
+  replicas: 6
   revisionHistoryLimit: 2
   selector:
     matchLabels:
@@ -144,6 +144,26 @@ spec:
                 secretKeyRef:
                   name: app-secrets
                   key: google-redirect-uri
+            - name: AWS_S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: aws-s3-bucket
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: aws-access-key-id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: aws-secret-access-key
+            - name: AWS_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: aws-region
           resources:
             requests:
               memory: '512Mi'

--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -8,39 +8,39 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: nestjs-app
-  minReplicas: 3
+  minReplicas: 6
   maxReplicas: 10
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 70
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        type: Utilization
-        averageUtilization: 80
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 300
       policies:
-      - type: Percent
-        value: 50
-        periodSeconds: 60
-      - type: Pods
-        value: 2
-        periodSeconds: 60
+        - type: Percent
+          value: 50
+          periodSeconds: 60
+        - type: Pods
+          value: 2
+          periodSeconds: 60
       selectPolicy: Min
     scaleUp:
       stabilizationWindowSeconds: 60
       policies:
-      - type: Percent
-        value: 100
-        periodSeconds: 60
-      - type: Pods
-        value: 4
-        periodSeconds: 60
+        - type: Percent
+          value: 100
+          periodSeconds: 60
+        - type: Pods
+          value: 4
+          periodSeconds: 60
       selectPolicy: Max

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -9,31 +9,31 @@ metadata:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/load-balancer-name: nestjs-eks-alb
-    
+
     # SSL/TLS 설정
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:ap-northeast-2:863518449560:certificate/b9aec76a-3962-418e-a03a-4827ef59dd4c
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
-    
+
     # Backend 프로토콜 설정
     alb.ingress.kubernetes.io/backend-protocol: HTTP
-    
+
     # 헬스체크 설정
     alb.ingress.kubernetes.io/healthcheck-path: /health
-    alb.ingress.kubernetes.io/healthcheck-interval-seconds: "30"
-    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "5"
-    alb.ingress.kubernetes.io/healthy-threshold-count: "2"
-    alb.ingress.kubernetes.io/unhealthy-threshold-count: "3"
-    
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: '30'
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: '5'
+    alb.ingress.kubernetes.io/healthy-threshold-count: '2'
+    alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
+
     # Socket.IO/WebSocket 지원을 위한 ALB 속성
-    alb.ingress.kubernetes.io/load-balancer-attributes: routing.http2.enabled=false,idle_timeout.timeout_seconds=300
-    
+    alb.ingress.kubernetes.io/load-balancer-attributes: routing.http2.enabled=true,idle_timeout.timeout_seconds=300
+
     # Sticky Session 설정 (Target Group 레벨)
     alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.type=lb_cookie,stickiness.lb_cookie.duration_seconds=86400
-    
+
     # Sticky Session 강화 (Actions 레벨)
     alb.ingress.kubernetes.io/actions.forward-single: '{"type":"forward","forwardConfig":{"targetGroups":[{"serviceName":"nestjs-service","servicePort":80,"weight":100}],"targetGroupStickinessConfig":{"enabled":true,"durationSeconds":86400}}}'
-    
+
     # 태그 설정
     alb.ingress.kubernetes.io/tags: Environment=production,Application=nestjs-app
 


### PR DESCRIPTION
- 부하 처리를 위해 최소 pod 개수를 3개에서 6개로 증가시켰습니다.
- 이미지 관련 기능 처리를 위해 s3관련 환경변수를 추가하였습니다.