### PR TITLE
[SCRUM-220] 게스트 회원가입(로그인)

### DIFF
--- a/src/user/dto/create-guest.dto.ts
+++ b/src/user/dto/create-guest.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateGuestDto {
+  @ApiProperty({
+    example: 'guest123',
+    description: '게스트 닉네임',
+  })
+  userName: string;
+} 

--- a/src/user/entity/user.entity.ts
+++ b/src/user/entity/user.entity.ts
@@ -14,8 +14,8 @@ export class User {
   @Column({ name: 'email', unique: true, nullable: false })
   email: string;
 
-  @Column({ name: 'password', nullable: true })
-  password: string;
+  @Column({ name: 'password', nullable: true, type: 'varchar', length: 100 })
+  password: string | null;
 
   @Column({ name: 'created_at', type: 'timestamp' })
   createdAt: Date;

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -25,6 +25,7 @@ import { OAuthCallbackDto } from './dto/oauth_callback_dto.dto';
 import { JwtAuthGuard } from 'src/auth/jwt.guard';
 import { AuthRequest } from 'src/interface/AuthRequest.interface';
 import { SignedCookies } from 'src/interface/SignedCookies.interface';
+import { CreateGuestDto } from './dto/create-guest.dto';
 
 @ApiTags('api/user')
 @Controller('api/user')
@@ -72,6 +73,13 @@ export class UserController {
       if (err instanceof HttpException) throw err;
       throw new NotFoundException('OAuth 실패');
     }
+  }
+
+  @Post('signup')
+  @ApiOperation({ summary: '게스트 회원가입(로그인) API' })
+  async guestSignUp(@Body() createGuestDto: CreateGuestDto) {
+    const result = await this.userService.guestSignUp(createGuestDto.userName);
+    return result;
   }
 
   @Get('info')


### PR DESCRIPTION
### 1. 기능 개요

- 프론트에서 닉네임(userName)만 받아 게스트 회원가입 및 JWT 토큰 발급이 가능하도록 API 추가
- 게스트는 uuid 기반 이메일로 가입, 닉네임 중복 허용
- 기존 유저와 구분되는 role 컬럼은 도입하지 않음(보류)

### 2. 주요 변경 내용

- **게스트 회원가입용 DTO 추가 및 Swagger 데코레이터 적용**
  - userName만 받는 DTO 생성
  - Swagger에서 입력 폼 및 예시 자동 생성

- **UserController에 게스트 회원가입 엔드포인트 추가**
  - `/api/user/signup` POST 엔드포인트 신설
  - Swagger 문서에 자동 노출

- **UserService에 게스트 회원가입 로직 추가**
  - uuid로 이메일 생성, 닉네임 저장, password는 null 처리
  - 이메일(uuid)만 유니크 체크, 닉네임 중복 허용
  - JWT 토큰 발급 및 응답 포맷 맞춤

- **User Entity 타입 보정**
  - password 필드가 null을 허용하도록 타입 명확화

- **DB 스키마와 Entity 구조 일치 확인**
  - 마이그레이션 불필요, 코드 수정만으로 적용 가능

