### PR TITLE
[SCRUM-222] 게스트 회원가입(로그인) 시 토큰 전달 방식 OAuth와 동일하게 변경

### DIFF
--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -77,9 +77,23 @@ export class UserController {
 
   @Post('signup')
   @ApiOperation({ summary: '게스트 회원가입(로그인) API' })
-  async guestSignUp(@Body() createGuestDto: CreateGuestDto) {
+  async guestSignUp(
+    @Body() createGuestDto: CreateGuestDto,
+    @Res({ passthrough: true }) res: Response
+  ) {
     const result = await this.userService.guestSignUp(createGuestDto.userName);
-    return result;
+    // access_token을 헤더로, refresh_token을 쿠키로 내려줌 (OAuth와 동일)
+    res.setHeader('Authorization', `Bearer ${result.access_token}`);
+    res.cookie('refresh_token', result.refresh_token, {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'none',
+      maxAge: 1 * 24 * 60 * 60 * 1000, // 1일
+      signed: true,
+    });
+    // 응답 바디에는 토큰 정보 포함하지 않고, 나머지 정보만 반환
+    const { access_token, refresh_token, ...rest } = result;
+    return rest;
   }
 
   @Get('info')


### PR DESCRIPTION
### 주요 변경 내용

- **게스트 회원가입(로그인) API의 토큰 전달 방식을 기존 OAuth 로그인과 동일하게 통일**
    - access_token은 응답 헤더(Authorization: Bearer ...)로만 전달
    - refresh_token은 httpOnly 쿠키로만 전달
    - 응답 바디에는 access_token, refresh_token을 포함하지 않고, 성공 메시지 등만 반환

### 기대 효과

- 게스트 로그인 시에도 새로고침 등에서 세션이 유지됨
- 보안적으로 refresh token이 노출되지 않아 안전함
- 기존 OAuth 로그인과 완전히 동일한 UX/동작 보장
