### PR TITLE
[SCRUM-227] 동점자 처리 개선 & 그룹 탈퇴 인원수 반영 버그 수정

### DIFF
--- a/src/group/group.service.ts
+++ b/src/group/group.service.ts
@@ -280,6 +280,7 @@ export class GroupService {
         throw new ConflictException('그룹에 가입되어 있지 않습니다.');
       }
       group.currentParticipantsCount -= 1;
+      await this.dataSource.manager.save(group); // 인원수 감소 반영
       await this.dataSource.manager.remove(groupUser);
     }
   }


### PR DESCRIPTION
### 1. 캔버스 히스토리 동점자 처리 로직 개선 (`canvas-history.service.ts`)
- top_try_user 선정 시:  
  - try_count 동점이면 own_count 많은 순, 그래도 동점이면 user_id 작은 순으로 우선순위 변경
- top_own_user 선정 시:  
  - own_count 동점이면 try_count 많은 순, 그래도 동점이면 user_id 작은 순으로 우선순위 변경

### 2. 그룹 탈퇴 시 인원수 반영 버그 수정 (`group.service.ts`)
- 그룹 탈퇴 시 currentParticipantsCount 감소 후,  
  group 엔티티를 DB에 저장하도록 하여  
  실제 인원수가 정확히 반영되도록 수정