### PR TITLE
[Fix] 워커 메모리 스펙 증가

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: nestjs-app
     component: api
 spec:
-  replicas: 6
+  replicas: 3
   revisionHistoryLimit: 2
   selector:
     matchLabels:
@@ -30,8 +30,24 @@ spec:
           ports:
             - containerPort: 3000
               name: http
-          # 헬스체크 설정 (무중단 배포 필수)
-          livenessProbe:
+          # 리소스 설정
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "500m"
+            limits:
+              memory: "2Gi"
+              cpu: "1000m"
+          # 상태 체크 프로브
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
             httpGet:
               path: /health
               port: 3000
@@ -39,22 +55,14 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
-          readinessProbe:
+          livenessProbe:
             httpGet:
               path: /health
               port: 3000
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 3
-            failureThreshold: 2
-          # 리소스 제한
-          resources:
-            requests:
-              memory: "256Mi"
-              cpu: "250m"
-            limits:
-              memory: "512Mi"
-              cpu: "500m"
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
           # Graceful shutdown
           lifecycle:
             preStop:
@@ -65,6 +73,8 @@ spec:
               value: 'production'
             - name: PORT
               value: '3000'
+            - name: NODE_OPTIONS
+              value: '--max-old-space-size=2048'
             # JWT Secret
             - name: JWT_SECRET
               valueFrom:
@@ -164,35 +174,4 @@ spec:
                 secretKeyRef:
                   name: app-secrets
                   key: aws-region
-          resources:
-            requests:
-              memory: '512Mi'
-              cpu: '250m'
-            limits:
-              memory: '1Gi'
-              cpu: '500m'
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 3000
-            initialDelaySeconds: 60
-            periodSeconds: 30
-            timeoutSeconds: 10
-            failureThreshold: 3
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: 3000
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
-          startupProbe:
-            httpGet:
-              path: /health
-              port: 3000
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
       terminationGracePeriodSeconds: 30

--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -8,7 +8,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: nestjs-app
-  minReplicas: 6
+  minReplicas: 3
   maxReplicas: 10
   metrics:
     - type: Resource

--- a/k8s/worker-deployment.yaml
+++ b/k8s/worker-deployment.yaml
@@ -20,24 +20,60 @@ spec:
         app: nestjs-worker
         component: worker
     spec:
+      # 파드 종료 시 유예 기간 증가
+      terminationGracePeriodSeconds: 120
       containers:
         - name: nestjs-worker
           image: 863518449560.dkr.ecr.ap-northeast-2.amazonaws.com/nestjs-app:latest
-          command: ["node", "dist/queues/bullmq.worker.js"]
+          command: ['node', 'dist/queues/bullmq.worker.js']
           # 리소스 제한
           resources:
             requests:
-              memory: "256Mi"
-              cpu: "250m"
+              memory: '4Gi'
+              cpu: '2000m'
             limits:
-              memory: "512Mi"
-              cpu: "500m"
-          # Graceful shutdown (Worker 프로세스용)
+              memory: '8Gi'
+              cpu: '4000m'
+          # Startup Probe 추가
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "pgrep -f 'node.*worker' > /dev/null"
+            failureThreshold: 30
+            periodSeconds: 10
+          # Readiness Probe 추가
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "pgrep -f 'node.*worker' > /dev/null"
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          # Liveness Probe
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "pgrep -f 'node.*worker' > /dev/null"
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          # Graceful shutdown
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "sleep 15"]
+                command: ['/bin/sh', '-c', 'sleep 15']
           env:
+            # Node.js 메모리 제한 설정
+            - name: NODE_OPTIONS
+              value: '--max-old-space-size=8192'
             - name: NODE_ENV
               value: 'production'
             # JWT Secret
@@ -119,11 +155,6 @@ spec:
                 secretKeyRef:
                   name: app-secrets
                   key: google-redirect-uri
-            - name: REDIS_TLS
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: redis-tls
             - name: AWS_S3_BUCKET
               valueFrom:
                 secretKeyRef:
@@ -144,23 +175,17 @@ spec:
                 secretKeyRef:
                   name: app-secrets
                   key: aws-region
-          resources:
-            requests:
-              memory: '256Mi'
-              cpu: '200m'
-            limits:
-              memory: '512Mi'
-              cpu: '400m'
-          # Worker 프로세스 상태 확인을 위한 간단한 probe
-          livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - "pgrep -f 'node.*worker' > /dev/null"
-            initialDelaySeconds: 60
-            periodSeconds: 30
-            timeoutSeconds: 10
-            failureThreshold: 3
       restartPolicy: Always
-      terminationGracePeriodSeconds: 60
+---
+# Pod Disruption Budget 추가
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: nestjs-worker-pdb
+  namespace: nestjs-app
+spec:
+  minAvailable: 1 # 항상 최소 1개의 pod가 사용 가능하도록 보장
+  selector:
+    matchLabels:
+      app: nestjs-worker
+      component: worker


### PR DESCRIPTION
🔧 EKS 리소스 조정 및 시뮬레이터 대응 리팩터링

변경사항
	•	워커 Pod OOM 해결을 위해 memory limit 상향 조정
	•	EKS 노드 타입을 t3.medium → c5.xlarge로 업그레이드하여 전체 리소스 확보
	•	Nest.js 앱 Pod 개수를 기존 6개 → 3개로 축소 (리소스 절감 및 테스트 기반 조정 목적)

배경
	•	시뮬레이터 도입 후 워커의 메모리 부족 이슈가 발생해, 안정적인 운영을 위해 리소스 증설
	•	노드 성능 개선으로 인해 여유 자원이 확보되어 Nest.js 앱 Pod 수 조정
	•	추후 부하 테스트 결과에 따라 HPA 기반 스케일 조정 검토 예정

추가 예정 사항
	•	시뮬레이터 부하 테스트 및 리소스 모니터링
	•	필요 시 HPA/Pod 수 재조정