### PR TITLE
[SCRUM-233] 계정별 롤 부여

### DIFF
--- a/sql/schema/add_role_to_user.sql
+++ b/sql/schema/add_role_to_user.sql
@@ -1,0 +1,5 @@
+ALTER TABLE users ADD COLUMN role VARCHAR(10) DEFAULT 'user';
+
+UPDATE users SET role = 'user' WHERE email LIKE '%@gmail.com%'
+UPDATE users SET role = 'guest' WHERE email LIKE '%@guest.local%';
+UPDATE users SET role = 'admin' WHERE email = 'pickpx0617@gmail.com';

--- a/src/interface/JwtPaylod.interface.ts
+++ b/src/interface/JwtPaylod.interface.ts
@@ -1,4 +1,4 @@
 export interface JwtPayload {
-  sub: { userId: string; nickName?: string };
+  sub: { userId: string; nickName?: string; role: 'admin' | 'user' | 'guest' };
   jti: string;
 }

--- a/src/user/entity/user.entity.ts
+++ b/src/user/entity/user.entity.ts
@@ -26,6 +26,9 @@ export class User {
   @Column({ name: 'user_name' })
   userName: string;
 
+  @Column({ name: 'role', type: 'varchar', length: 10, default: 'user' })
+  role: 'admin' | 'user' | 'guest';
+
   @OneToMany(() => UserCanvas, (uc) => uc.user)
   userCanvases: UserCanvas[];
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -116,10 +116,11 @@ export class UserService {
         createdAt: new Date(),
         updatedAt: new Date(),
         userName: userInfo.userName,
+        role: 'user',
       });
       try {
         const result = await this.userRepository.save(newUser);
-        const token = this.authService.generateJWT(result.id, result.userName);
+        const token = this.authService.generateJWT(result.id, result.userName, result.role);
         return token;
       } catch (err) {
         const existUser = await this.userRepository.findOne({
@@ -128,10 +129,10 @@ export class UserService {
 
         if (!existUser) throw new Error('동시성 문제 발생!');
 
-        return this.authService.generateJWT(existUser.id, existUser.userName);
+        return this.authService.generateJWT(existUser.id, existUser.userName, existUser.role);
       }
     } else {
-      return this.authService.generateJWT(user.id, user.userName);
+      return this.authService.generateJWT(user.id, user.userName, user.role);
     }
   }
 
@@ -268,9 +269,10 @@ export class UserService {
       createdAt: now,
       updatedAt: now,
       userName: userName,
+      role: 'guest',
     });
     const saved: User = await this.userRepository.save(newUser);
-    const token = await this.authService.generateJWT(saved.id, saved.userName);
+    const token = await this.authService.generateJWT(saved.id, saved.userName, saved.role);
     return {
       isSuccess: true,
       code: '200',


### PR DESCRIPTION
## 1.  백엔드 변경점 요약

### [주요 변경 내역]

1. **DB 스키마 변경**
   - `users` 테이블에 `role` 컬럼(`'admin' | 'user' | 'guest'`) 추가
   - 기존 유저 role 일괄 업데이트 SQL 작성(`add_role_to_user.sql`)

2. **유저 생성 로직(role 자동 할당)**
   - 구글 OAuth 신규 유저: role = 'user'
   - 게스트 로그인 신규 유저: role = 'guest'
   - 시드 유저(관리자)는 SQL로만 role = 'admin' 부여

3. **JWT 토큰 구조 변경**
   - 모든 JWT(Access/Refresh) 토큰 payload에 role 정보 포함
   - 예시:  
     ```json
     {
       "sub": { "userId": "1", "nickName": "홍길동", "role": "user" },
       "jti": "..."
     }
     ```

4. **토큰 재발급, 레디스 저장, 소켓 인증 등 모든 경로에서 role이 payload에 포함되도록 통일**

5. **기타**
   - 관련 인터페이스(JwtPayload) 및 서비스 함수 시그니처 수정
   - 마이그레이션 파일은 DB에 직접 실행 필요(파일만 올려서는 적용되지 않음)

---

## 2. 프론트엔드 전달용 명세

### [JWT 구조 및 권한 명세 변경 안내]

#### 1. JWT 토큰 구조 변경

- **변경 전**
  ```json
  {
    "sub": { "userId": "1", "nickName": "홍길동" },
    "jti": "..."
  }
  ```
- **변경 후**
  ```json
  {
    "sub": { "userId": "1", "nickName": "홍길동", "role": "user" }, // role: 'admin' | 'user' | 'guest'
    "jti": "..."
  }
  ```

#### 2. 적용 범위

- Access Token, Refresh Token 모두 동일하게 role 포함
- 토큰 재발급, 소켓 인증 등 모든 경로에서 role이 항상 포함됨

#### 3. 프론트엔드 영향

- 토큰 디코딩 시 payload.sub.role로 유저 권한 확인 가능
- 권한별 UI/기능 분기(예: admin만 보이는 버튼 등) 구현 가능

#### 4. 예시

```js
// 토큰 디코딩 예시 (프론트)
const payload = jwt_decode(token);
const role = payload.sub.role; // 'admin' | 'user' | 'guest'
```

#### 5. 주의사항

- 기존 토큰에는 role이 없으니, 배포 후 새로 로그인/토큰 재발급 받아야 role 정보가 포함됩니다.
- 게스트 회원가입 API 경로는 `/api/user/signup`입니다. (오타 주의: users 아님)

